### PR TITLE
Channel students back to active session

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -22,12 +22,12 @@
         <div class="col-lg-6 help">
           <div class = "help-container">
             <h2>You can get help from an Academic Coach.</h2>
-	    <button v-if="!hasActiveSession()" class="btn getHelp" @click.prevent="getHelp()">
-	      Get help now
-	    </button>
-	    <button v-if="hasActiveSession()" class="btn getHelp" @click.prevent="rejoinHelpSession()">
-	      Rejoin your coaching session
-	    </button>
+            <button v-if="!hasActiveSession()" class="btn getHelp" @click.prevent="getHelp()">
+              Get help now
+            </button>
+            <button v-if="hasActiveSession()" class="btn getHelp" @click.prevent="rejoinHelpSession()">
+              Rejoin your coaching session
+            </button>
             <div
               v-if="showHelpPopUp"
               :style="popUpStyle"

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -22,9 +22,12 @@
         <div class="col-lg-6 help">
           <div class = "help-container">
             <h2>You can get help from an Academic Coach.</h2>
-            <button
-              class="btn getHelp"
-              @click.prevent="getHelp()">Get help now</button>
+	    <button v-if="!hasActiveSession()" class="btn getHelp" @click.prevent="getHelp()">
+	      Get help now
+	    </button>
+	    <button v-if="hasActiveSession()" class="btn getHelp" @click.prevent="rejoinHelpSession()">
+	      Rejoin your coaching session
+	    </button>
             <div
               v-if="showHelpPopUp"
               :style="popUpStyle"
@@ -93,6 +96,7 @@
 <script>
 
 import UserService from 'src/services/UserService';
+import SessionService from 'src/services/SessionService';
 
 import ListSessions from 'src/components/ListSessions';
 
@@ -102,6 +106,8 @@ export default {
   },
   data() {
     const user = UserService.getUser() || {};
+    SessionService.getCurrentSession(this, user);
+
     const subtopics = {
       math: ['Algebra', 'Geometry', 'Trigonometry', 'Precalculus', 'Calculus'],
       esl: ['General Help'],
@@ -126,6 +132,14 @@ export default {
     };
   },
   methods: {
+    hasActiveSession() {
+      return localStorage.getItem('currentSessionPath');
+    },
+    rejoinHelpSession() {
+      const sessionPath = localStorage.getItem('currentSessionPath');
+      window.location.hash = `#${sessionPath}`;
+      window.location.reload(true);
+    },
     getHelp() {
       this.popUpStyle = {
         display: 'flex',

--- a/src/components/Session/Header.vue
+++ b/src/components/Session/Header.vue
@@ -89,11 +89,12 @@ export default {
       ) {
         volunteerId = SessionService.currentSession.data.volunteer._id;
       }
+
       const result = window.confirm("Do you really want to end the session?");
       if (result) {
         if (volunteerId) {
           this.$socket.disconnect();
-          SessionService.endSession({ skipRoute: true });
+	  SessionService.endSession(this, sessionId, { skipRoute: true });
           const url =
             "/feedback/" +
             sessionId +
@@ -105,6 +106,7 @@ export default {
             volunteerId;
           router.replace(url);
         } else {
+	  SessionService.endSession(this, sessionId, { skipRoute: true });
           router.replace("/");
         }
       }

--- a/src/services/NetworkService.js
+++ b/src/services/NetworkService.js
@@ -52,6 +52,9 @@ export default {
   checkSession(context, data) {
     return context.$http.post(`${API_ROOT}/session/check`, data).then(this._successHandler, this._errorHandler);
   },
+  currentSession(context, data) {
+    return context.$http.post(`${API_ROOT}/session/current`, data).then(this._successHandler, this._errorHandler);
+  },
   getQuestions(context, data) {
     return context.$http.post(`${API_ROOT}/training/questions`, data).then(this._successHandler, this._errorHandler);
   },

--- a/src/services/NetworkService.js
+++ b/src/services/NetworkService.js
@@ -46,6 +46,9 @@ export default {
   newSession(context, data) {
     return context.$http.post(`${API_ROOT}/session/new`, data).then(this._successHandler, this._errorHandler);
   },
+  endSession(context, data) {
+    return context.$http.post(`${API_ROOT}/session/end`, data).then(this._successHandler, this._errorHandler);
+  },
   checkSession(context, data) {
     return context.$http.post(`${API_ROOT}/session/check`, data).then(this._successHandler, this._errorHandler);
   },

--- a/src/services/SessionService.js
+++ b/src/services/SessionService.js
@@ -21,12 +21,21 @@ export default {
     return session.volunteer;
   },
 
-  endSession(options = {}) {
-    this.currentSession.sessionId = null;
-    this.currentSession.data = {};
-    if (!options.skipRoute) {
-      router.replace('/feedback');
-    }
+  endSession(context, sessionId, options = {}) {
+    return NetworkService
+      .endSession(context, { sessionId })
+      .then(res => {
+        const data = res.data || {};
+        const { sessionId } = data;
+
+        console.log(`ended session: ${sessionId}`);
+        this.currentSession.sessionId = null;
+        this.currentSession.data = {};
+
+        if (!options.skipRoute) {
+          router.replace('/feedback');
+        }
+      })
   },
 
   newSession(context, sessionType, sessionSubTopic) {


### PR DESCRIPTION
Currently, if a student navigates away from an active coaching session, they have no convenient way to get back to it using the UI. 

This PR adds a "Rejoin your coaching session" button to the dashboard page that takes the place of the "Get help now" button that's currently always displayed.

1. When loading the home page, we check for an active session (see the backed PR for how we do that) using `SessionService.getCurrentSession(this, user)` and store its path in localStorage if we find one.

2. If there's an active session, we display the "rejoin" button.

3. When ending a session, invoke `SessionService.endSession` to persist the endTime for the current session and clear the session path from localStorage.

### Demo

(Click to view enlarged)

![demo](https://user-images.githubusercontent.com/4433943/53453875-74beac80-39f3-11e9-8091-a49368bf9bfb.gif)

Related: https://github.com/UPchieve/server/pull/67
https://app.asana.com/0/inbox/1108906145495473/1110715446927717/1110717696165263