### PR TITLE
Channel volunteer back to active session if one exists

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -79,10 +79,17 @@
           </div>
         </div>
         <div class="col-lg-6 help">
-          <div class = "help-container">
+          <div class="help-container">
             <h2>You are ready to help!</h2>
-            <p> Only students who are waiting for a volunteer will show up below.</p>
-            <list-sessions/>
+            <div v-if="hasActiveSession()">
+              <button class="btn getHelp" @click.prevent="rejoinHelpSession()">
+                Rejoin your coaching session
+              </button>
+            </div>
+            <div v-if="!hasActiveSession()">
+              <p> Only students who are waiting for a volunteer will show up below.</p>
+              <list-sessions/>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/ListSessions.vue
+++ b/src/components/ListSessions.vue
@@ -43,8 +43,11 @@ export default {
   },
   methods: {
     gotoSession(session) {
-      console.log(session._id);
-      router.push(`/session/${session.type}/${session.subTopic}/${session._id}`);
+      const path = `/session/${session.type}/${session.subTopic}/${session._id}`;
+      localStorage.setItem('currentSessionPath', path);
+      console.log(`joining session: ${path}`);
+      window.location.hash = `#${path}`;
+      window.location.reload(true);
     },
   },
   sockets: {


### PR DESCRIPTION
Currently a volunteer cannot navigate back to an active session using the UI if they navigate away from it. This patch adds a button to the dashboard to do just that by setting `currentSessionPath` in localStorage as appropriate.

### Demo
![demo](https://user-images.githubusercontent.com/4433943/53587803-507ce000-3b59-11e9-89a8-557e612698cf.gif)
