### PR TITLE
Fix dashboard UPchieve logo

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -66,9 +66,9 @@ h1::before {
   content: "";
   display: inline-block;;
   width: 100px;
-  height: 50px;
+  height: 43px;
   background-image: url('../assets/logo-01.svg');
-  background-size: 100px 50px;
+  background-size: 100px 43px;
   top: 0;
   left: 0;
 }


### PR DESCRIPTION
Resizes the UPchieve logo on the dashboard.

### Before

<img width="512" alt="screen shot 2019-03-01 at 7 48 23 pm" src="https://user-images.githubusercontent.com/4433943/53674312-0e3bc780-3c5b-11e9-9ad4-fb6166f18cd0.png">

### After 
<img width="421" alt="screen shot 2019-03-01 at 7 48 15 pm" src="https://user-images.githubusercontent.com/4433943/53674309-0da33100-3c5b-11e9-96d6-6b4b95dd4a98.png">