### PR TITLE
WIP: Update Quiz.hasCompleted

### DIFF
--- a/src/components/Quiz.vue
+++ b/src/components/Quiz.vue
@@ -278,7 +278,7 @@ export default {
     },
     submit () {
       TrainingService.saveAnswer(this, this.picked)
-      if (TrainingService.hasCompleted(this)) {
+      if (TrainingService.hasCompleted()) {
         TrainingService.submitQuiz(this, this.user._id).then(data => {
           if (data.passed) {
             this.passedMsg = 'You passed!'

--- a/src/services/TrainingService.js
+++ b/src/services/TrainingService.js
@@ -27,7 +27,7 @@ export default {
     return this.index
   },
   hasCompleted () {
-    return this.numAnswers === this.questions.length
+    return this.numAnswers >= this.questions.length
   },
   hasNext () {
     return this.index + 1 < this.questions.length


### PR DESCRIPTION
Bug: If a volunteer takes a quiz and submits the same question more than once (e.g. if they revise their response to a question already answered, then the number of answers `numAnswers` is greater than the number of questions.

Since submission of quizzes is guarded by a conditional checking for equality, this means that revising your old answers blocks you from submitting your quiz. 

This patch updates `Quiz#hasCompleted` so that it checks for having received a count of responses greater than the number of questions.

WIP: This patch is just for illustrative purposes: it still allows for an error state (re-submit one response 15 times, answer no other questions, and you can submit the quiz). An actual fix will require keeping track of which questions have been answered and making submission of the quiz conditional on all questions being answered.

![demo](https://user-images.githubusercontent.com/4433943/54796955-baece180-4c28-11e9-8d3f-e3d44f7620d7.gif)

Resolves https://github.com/UPchieve/web/issues/141