### PR TITLE
Add MathJax rendering to certification quizzes

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,5 +10,24 @@
   <body>
     <div id="app"></div>
     <!-- built files will be auto injected -->
+
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        "HTML-CSS": {
+          preferredFont: null,
+          webFont: "STIX-Web",
+          scale: 120
+        },
+        CommonHTML: {
+          preferredFont: null,
+          webFont: "STIX-Web",
+          scale: 120
+        },
+        SVG: {
+          font: "STIX-Web",
+          scale: 120
+        }
+      })
+    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <title>UPchieve</title>
     <link href="https://fonts.googleapis.com/css?family=Work+Sans:300,400,500,600,700" rel="stylesheet">
     <link rel="shortcut icon" type="image/png" href="/static/favicon.png"/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/src/components/Quiz.vue
+++ b/src/components/Quiz.vue
@@ -198,9 +198,6 @@ export default {
       this.quizLength = quizLength
     })
   },
-  beforeUpdate () {
-    this.clearMathJaxElements()
-  },
   updated () {
     this.rerenderMathJaxElements()
   },
@@ -241,6 +238,10 @@ export default {
           element.style.background = '#EEEEEE'
         }
       }
+
+      // When switching to a new question, clear any mathjax elements so they
+      // can be re-rendered
+      this.clearMathJaxElements()
     },
     styleImage (image) {
       if (image) {

--- a/src/components/Quiz.vue
+++ b/src/components/Quiz.vue
@@ -210,16 +210,14 @@ export default {
       const mathJaxElements = quizBody.querySelectorAll('[class*=mjx],[class*=MathJax],[id*=MathJax]')
       Array.from(mathJaxElements).forEach(e => e.remove())
 
-      // MathJax slices up the DOM nodes it renders as Math. We need to rejoin
-      // these to avoid rendering artifacts being left behind
+      // MathJax slices up the DOM nodes it renders as math formulas. We need to
+      // rejoin these under the first child's data attribute to avoid artifacts
+      // being left behind
       const questionText = quizBody.querySelector('.questionText')
-      questionText.childNodes[0].data = questionText.innerText
+      questionText.firstChild.data = questionText.innerText
 
-      // Use a while loop because childNodes is a live collection
-      // https://developer.mozilla.org/en-US/docs/Web/API/NodeList#A_sometimes-live_collection
-      while (questionText.childNodes.length > 1) {
-        questionText.removeChild(questionText.childNodes[1])
-      }
+      // Remove all child nodes but the first
+      Array.from(questionText.childNodes).slice(1).forEach(e => e.remove())
     },
 
     rerenderMathJaxElements () {

--- a/src/components/Quiz.vue
+++ b/src/components/Quiz.vue
@@ -255,11 +255,10 @@ export default {
         }
       }
     },
-    styleImage (image) {
-      if (image) {
-        const questionImage = `../../../static/question_images/${image}`
+    styleImage (imageSrc) {
+      if (imageSrc) {
         this.imageStyle = {
-          backgroundImage: `url(${questionImage})`,
+          backgroundImage: `url(${imageSrc})`,
           width: '300px',
           height: '300px',
           display: 'flex',
@@ -273,7 +272,7 @@ export default {
     getFirst () {
       const question = TrainingService.getFirstQuestion(this)
       this.questionText = question.questionText
-      this.styleImage(question.image)
+      this.styleImage(question.imageSrc)
       this.items = question.possibleAnswers
       this.showStartMsg = false
       this.showStart = false
@@ -289,7 +288,7 @@ export default {
       this.picked = data.picked
       this.questionText = question.questionText
       this.updateProgressBar()
-      this.styleImage(question.image)
+      this.styleImage(question.imageSrc)
       this.items = question.possibleAnswers
       if (!TrainingService.hasPrevious(this)) {
         this.showPrevious = false
@@ -308,7 +307,7 @@ export default {
       this.picked = data.picked
       this.questionText = question.questionText
       this.updateProgressBar()
-      this.styleImage(question.image)
+      this.styleImage(question.imageSrc)
       this.items = question.possibleAnswers
       if (!TrainingService.hasNext(this)) {
         this.showNext = false
@@ -381,12 +380,9 @@ export default {
     review () {
       this.questionsReview = TrainingService.reviewQuiz(this)
       this.questionsReview.forEach(question => {
-        if (question.image) {
-          const questionImage = `../../../static/question_images/${
-            question.image
-          }`
+        if (question.imageSrc) {
           question.imageStyle = {
-            backgroundImage: `url(${questionImage})`,
+            backgroundImage: `url(${question.imageSrc})`,
             width: '300px',
             height: '300px',
             display: 'flex',

--- a/src/components/Quiz.vue
+++ b/src/components/Quiz.vue
@@ -59,9 +59,9 @@
           <div v-for="(item, index) in items" :key="`item-${index}`">
             <div class="options">
               <input :value="item.val" v-model="picked" type="radio" />
-              <label :for="item.val" :id="'answer-' + item.val"
-                >{{ item.val }}. {{ item.txt }}</label
-              >
+              <label :for="item.val" :id="'answer-' + item.val">
+                {{ item.val }}. {{ item.txt }}
+              </label>
             </div>
           </div>
         </form>
@@ -198,7 +198,34 @@ export default {
       this.quizLength = quizLength
     })
   },
+  beforeUpdate () {
+    this.clearMathJaxElements()
+  },
+  updated () {
+    this.rerenderMathJaxElements()
+  },
   methods: {
+    clearMathJaxElements () {
+      // Remove any MathJax-rendered elements from the DOM.
+      // Do this before updating to avoid rendering artifacts being left behind
+      const mathJaxElements = document.querySelectorAll('.mjx-chtml')
+      Array.from(mathJaxElements).forEach(node => node.remove())
+    },
+    rerenderMathJaxElements () {
+      // Re-render MathJax in question text and answer choices
+      const quiz = document.querySelector('.quizBody')
+      const questionText = quiz.querySelector('.questionText')
+      const answerChoices = quiz.querySelector('.possibleAnswers')
+
+      if (!questionText || !answerChoices) {
+        return
+      }
+
+      MathJax.Hub.Queue(
+        ['Typeset', MathJax.Hub, questionText],
+        ['Typeset', MathJax.Hub, answerChoices]
+      )
+    },
     reload () {
       this.$router.go(this.$router.currentRoute)
     },

--- a/src/components/Sidebar/UserNav.vue
+++ b/src/components/Sidebar/UserNav.vue
@@ -4,39 +4,47 @@
       v-if="$route.path.indexOf('/onboarding') !== -1 && !user.isVolunteer"
       class="nav navbar-nav"
     >
-      <router-link to="/onboarding/profile" tag="li"
-        ><a class="profile-info">Basic Profile</a></router-link
-      >
-      <router-link to="/onboarding/academic" tag="li"
-        ><a class="profile-info">First Time Use Survey</a></router-link
-      >
+      <router-link to="/onboarding/profile" tag="li">
+        <a class="profile-info">Basic Profile</a>
+      </router-link>
+      <router-link to="/onboarding/academic" tag="li">
+        <a class="profile-info">First Time Use Survey</a>
+      </router-link>
     </ul>
     <ul
       v-else-if="$route.path.indexOf('/onboarding') !== -1"
       class="nav navbar-nav"
     >
-      <router-link to="/onboarding/profile" tag="li"
-        ><a class="profile-info">Basic Profile</a></router-link
-      >
+      <router-link to="/onboarding/profile" tag="li">
+        <a class="profile-info">Basic Profile</a>
+      </router-link>
     </ul>
     <ul v-else-if="auth.authenticated" class="nav navbar-nav">
-      <router-link to="/dashboard" tag="li"
-        ><a class="home icon">Home</a></router-link
-      >
+      <router-link to="/dashboard" tag="li">
+        <a class="home icon">Home</a>
+      </router-link>
+
       <template v-if="user.isVolunteer">
-        <router-link to="/training" tag="li"
-          ><a class="training icon">Training</a></router-link
-        >
-        <router-link to="/calendar" tag="li"
-          ><a class="schedule icon">Schedule</a></router-link
-        >
+        <router-link to="/training" tag="li">
+          <a class="training icon">Training</a>
+        </router-link>
+        <router-link to="/calendar" tag="li">
+          <a class="schedule icon">Schedule</a>
+        </router-link>
       </template>
-      <router-link to="/profile" tag="li"
-        ><a class="profile icon">Profile</a></router-link
-      >
-      <router-link to="/resources" tag="li"
-        ><a class="resources icon">Useful Information</a></router-link
-      >
+
+      <template v-if="user.isAdmin">
+        <router-link to="/edu" tag="li">
+          <a class="resources icon">EDU Admin</a>
+        </router-link>
+      </template>
+
+      <router-link to="/profile" tag="li">
+        <a class="profile icon">Profile</a>
+      </router-link>
+      <router-link to="/resources" tag="li">
+        <a class="resources icon">Useful Information</a>
+      </router-link>
     </ul>
   </div>
 </template>

--- a/src/router.js
+++ b/src/router.js
@@ -70,6 +70,12 @@ const routes = [
     meta: { protected: true, bypassOnboarding: true }
   },
   {
+    path: '/edu',
+    component: () => {
+      window.location.href = '/edu'
+    }
+  },
+  {
     path: '/feedback/:sessionId/:userType/:studentId/:volunteerId',
     component: Feedback,
     meta: { protected: true }


### PR DESCRIPTION
Adds a dependency on MathJax to render mathematical notation more
legibly.

Use:

- `\[ ... \]` for block math
- `\( ... \)` for inline math

TODO:

- [x] Fix disappearing math

### Before
<img width="782" alt="Screen Shot 2019-04-01 at 8 57 56 AM" src="https://user-images.githubusercontent.com/4433943/55329337-57e72000-545c-11e9-9194-01e2b446d4c1.png">

### After

after updating question text to:

```
Evaluate the following: \(  -6^2 + 4 \cdot 3^2  \)
```

<img width="451" alt="Screen Shot 2019-04-01 at 8 54 51 AM" src="https://user-images.githubusercontent.com/4433943/55329319-4ef64e80-545c-11e9-80db-25318dd46f1c.png">

Resolves: https://app.asana.com/0/775116702697292/1115872002804915
