### PR TITLE
Fix calendar rendering

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -8,7 +8,7 @@
       <div class="tz-selector-container">
         <span>Time Zone: </span>
         <select v-model="selectedTz">
-          <option v-for="tz in tzList">
+          <option v-for="tz in tzList" :key="tz">
             {{ tz }}
           </option>
         </select>

--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -45,6 +45,7 @@
 
 <script>
 import moment from 'moment-timezone'
+import lodash from 'lodash';
 import UserService from 'src/services/UserService'
 import CalendarService from '../services/CalendarService'
 


### PR DESCRIPTION
Asana: https://app.asana.com/0/1115766615375295/1115439483057742
Fixes https://github.com/UPchieve/web/issues/69

- Use async/await to fetch user's availability, which resolves the promise before continuing in the component's lifecycle. The bug was caused by a race condition where the `CalendarService.getAvailability` method often wouldn't resolve immediately.
- Only show the timezone selector & schedule once the user's availability has loaded.

This is just a quick fix. I don't think we generally want to delay the Vue lifecycle hooks and wait for data to load. Instead, we should show some default data and/or a loading state until async data has loaded.