### PR TITLE
Disable "Get Help" button until form is complete

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -42,10 +42,16 @@
             <div v-if="showHelpPopUp" :style="popUpStyle" class="getHelpPopUp">
               <span>Select a help topic.</span>
               <select v-model="pickedTopic" class="form-control topic">
+                <option value="" disabled>Select a topic</option>
                 <option value="math">Math</option>
                 <option value="college">College Counseling</option>
               </select>
-              <select v-model="pickedSubtopic" class="form-control subtopic">
+              <select
+                v-model="pickedSubtopic"
+                class="form-control subtopic"
+                :disabled="pickedTopic === ''"
+              >
+                <option value="" disabled>Select a subtopic</option>
                 <option
                   v-for="(subtopic, index) in subtopics[pickedTopic]"
                   :key="`subtopic-${index}`"
@@ -65,6 +71,7 @@
                   v-if="showHelpPopUp"
                   class="btn helpNext"
                   type="next"
+                  :disabled="pickedSubtopic === ''"
                   @click.prevent="getHelpNext()"
                 >
                   Get help
@@ -155,6 +162,11 @@ export default {
       pickedSubtopic: '',
       subtopics,
       coverStyle: {}
+    }
+  },
+  watch: {
+    pickedTopic: function () {
+      this.pickedSubtopic = ''
     }
   },
   methods: {
@@ -322,6 +334,10 @@ h3 {
 
 .btn:hover {
   background-color: #16d2aa;
+}
+
+.btn:disabled {
+  color: white;
 }
 
 .form-control {

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -165,6 +165,7 @@ export default {
     }
   },
   watch: {
+    // Watch the help topic for changes, and reset the subtopic when it does.
     pickedTopic: function () {
       this.pickedSubtopic = ''
     }


### PR DESCRIPTION
https://app.asana.com/0/775116702697292/1114219095361199

- Added disabled `<option>` tags to the topic and subtopic `<select>`s.
- Set the subtopic `<select>` to be disabled until the topic has been selected.
- Set the "Get help" button to be disabled until the subtopic has been selected.
- Added a watch callback to reset `pickedSubtopic` whenever `pickedTopic` is changed.
- Added a CSS rule for disabled buttons to prevent color change on hover.