### PR TITLE
Conditionally Allows Email for Password Reset 

### DIFF
--- a/src/components/ResetPasswordForm.vue
+++ b/src/components/ResetPasswordForm.vue
@@ -8,21 +8,26 @@
           / <router-link to="login" class="login-link">Log In</router-link>
         </p>
       </div>
-      <label for="inputEmail">Please enter your email address</label>
-      <input
-        id="inputEmail"
-        v-model="email"
-        type="text"
-        class="form-control"
-        required
-        autofocus
-      />
+      <div v-if="this.firstTime === true">
+        <label for="inputEmail">Please enter your email address</label>
+        <input
+          id="inputEmail"
+          v-model="email"
+          type="text"
+          class="form-control"
+          required
+          autofocus
+        />
+      </div>
+      <div v-else>
+        <p class = "message"> Send password reset email to {{this.email}}?</p>
+      </div>
       <button
         class="btn btn-lg btn-primary btn-block"
         type="submit"
         @click.prevent="submit()"
       >
-        ENTER
+        SEND
       </button>
       {{ msg }}
     </form>
@@ -31,12 +36,24 @@
 
 <script>
 import AuthService from '../services/AuthService'
-
+import UserService from '../services/UserService'
 export default {
   data () {
     return {
+      firstTime: null,
       email: '',
       msg: ''
+    }
+  },
+  mounted () {
+    let auth = UserService.getAuth()
+    if (auth.authenticated) {
+      let user = UserService.getUser()
+      this.email = user.email
+      this.firstTime = false
+    }
+    else{
+      this.firstTime = true
     }
   },
   methods: {
@@ -104,6 +121,10 @@ label {
   font-size: 16px;
   font-weight: 400;
   color: #343440;
+}
+
+.message {
+  margin-bottom: 10px;
 }
 .form-control {
   border-bottom: 3px solid #16d2aa;

--- a/src/components/SetPasswordForm.vue
+++ b/src/components/SetPasswordForm.vue
@@ -3,15 +3,6 @@
   <div class="reset-page">
     <form class="form-resetpassword">
       <h2 class="form-resetpassword-heading">Reset Your Password</h2>
-      <label for="inputEmail">Please enter your email address</label>
-      <input
-        id="inputEmail"
-        v-model="credentials.email"
-        type="text"
-        class="form-control"
-        required
-        autofocus
-      />
       <label for="inputPassword">Create a new password</label>
       <input
         id="inputPassword"
@@ -54,7 +45,6 @@ export default {
       msg: '',
       credentials: {
         token: '',
-        email: '',
         password: '',
         newpassword: ''
       }
@@ -64,7 +54,6 @@ export default {
     submit () {
       AuthService.confirmReset(this, {
         token: this.$route.params.token,
-        email: this.credentials.email,
         password: this.credentials.password,
         newpassword: this.credentials.newpassword
       })


### PR DESCRIPTION

Links
-----
Task: https://www.notion.so/upchieve/2-issues-with-reset-password-link-user-input-email-643910b97c9f41608c3abe4446ccde4c

Description
-----------
Two Bugs
1. After user received the reset password email, they needed to re-input their email. No need for this because already sending verification token which, according to standard reset password practices, is secure enough. Instead only uses token to identify user, and then updates password given that.
2. There were to instances when the password needs to be reset: when the password is forgotten so you cannot login or when the user would like to change their password. These instances should be treated differently, for the user should not have to re-input their email if they are already logged in. Changed to only allowing user to input email if no user is logged in.

Important!: Also got rid of # signs that were in both volunteer verification emails and password reset emails. This is crucial, for as of now users are not receiving valid links via email.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] PR link has been posted in the task's comments
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested
- [x] Task and PR have been updated to show that this is ready for review
