### PR TITLE
removed named capturing group from regex

### DIFF
--- a/src/components/Registration/VolunteerSignupForm.vue
+++ b/src/components/Registration/VolunteerSignupForm.vue
@@ -186,7 +186,7 @@ var phoneValidation = function() {
     // see http://regexlib.com/REDetails.aspx?regexp_id=58
     // modified to ignore trailing/leading whitespace,
     // and disallow alphanumeric characters
-    re: /^\s*(?<cc>[0-9](?: |-)?)?(?:\(?([0-9]{3})\)?|[0-9]{3})(?: |-)?(?:([0-9]{3})(?: |-)?([0-9]{4}))\s*$/,
+    re: /^\s*([0-9](?: |-)?)?(?:\(?([0-9]{3})\)?|[0-9]{3})(?: |-)?(?:([0-9]{3})(?: |-)?([0-9]{4}))\s*$/,
     validatePhoneNumber: function(v) {
       return this.re.test(v);
     },


### PR DESCRIPTION
Links
-----
Task: https://www.notion.so/upchieve/Phone-number-regex-validation-crashes-Firefox-other-non-Chrome-browsers-2627c2779fdd41feba76fdd3750fc117

Related PRs: https://github.com/UPchieve/web/pull/171 (original validation PR)

Description
-----------
My regex for validating U. S. phone numbers included a named capturing group. This is an ES2018 feature that is not supported in all browsers, and browsers that don't support it yet (such as Firefox) will read it as a syntax error and crash. This PR removes the named capturing group and replaces it with an ordinary capturing group, which is sufficient for our purposes.

In the future, we may want to install some plugins like the following, so that we can transform such features into constructs that are compatible with older browsers:

https://babeljs.io/docs/en/babel-plugin-transform-named-capturing-groups-regex

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] PR link has been posted in the task's comments
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested on multiple browsers
- [ ] Task and PR have been updated to show that this is ready for review
