### PR TITLE
Fix route name bug

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
           v-if="!isActive"
           @click="toggleMenu()"
           class="sidebar-hamburger"
-          v-bind:class="{white: $route.name === 'Dashboard'}"
+          v-bind:class="{white: $route.name === 'DashboardView'}"
         />
 
         <button v-else @click="toggleMenu()" class="sidebar-exit" />


### PR DESCRIPTION
Links
-----
Task: https://www.notion.so/upchieve/Vue-route-name-changes-cause-issues-hamburger-menu-icon-on-dashboard-99e6cf41c1ab4a1e9298f7cc141903a8

Description
------------
- Renamed route name `Dashboard` to `DashboardView` in App.vue

I performed various searches on the code base, and this is the only use of a route name.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] PR link has been posted in the task's comments
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested on multiple browsers
- [x] Task and PR have been updated to show that this is ready for review
