### PR TITLE
Auto saves calendar input

### DIFF
--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -2,6 +2,7 @@
   <div class="calendar">
     <h1 class="header">
       <div class="header-title">Schedule</div>
+      <button class="btn" @click="save()">Update Schedule</button>
     </h1>
     <div v-if="hasUserSchedule">
       <div class="tz-selector-container">
@@ -91,6 +92,7 @@ export default {
     this.save()
     next()
   },
+
   computed: {
     sortedTimes() {
       return this.sortTimes();
@@ -101,8 +103,15 @@ export default {
   },
   created() {
     this.fetchData();
+    //to catch reloading and exiting page
+    window.addEventListener('beforeunload', this.leaving)
   },
   methods: {
+    leaving(event) {
+      this.save()
+      event.preventDefault()
+      event.returnValue = ''
+    },
     fetchData() {
       if (!this.user.hasSchedule) {
         CalendarService.initAvailability(this, this.user._id);

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -2,7 +2,6 @@
   <div class="calendar">
     <h1 class="header">
       <div class="header-title">Schedule</div>
-      <button class="btn" @click="save()">Update Schedule</button>
     </h1>
     <div v-if="hasUserSchedule">
       <div class="tz-selector-container">
@@ -85,6 +84,12 @@ export default {
       tzList: moment.tz.names(),
       selectedTz: ""
     };
+  },
+  beforeRouteLeave (to, from, next) {
+    // called when the route that renders this component is about to
+    // be navigated away from.
+    this.save()
+    next()
   },
   computed: {
     sortedTimes() {


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Calendar-auto-save-78b3a3f97b034e749fbbad01ea748e41

Description
-----------
- Makes it so calendar auto-saves before route is navigated away. 

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested (on multiple browsers)
- [x] All new code complies with our ESLint standards
