### PR TITLE
Fix Chrome password auto-save

### DIFF
--- a/src/views/SignupView/StudentForm.vue
+++ b/src/views/SignupView/StudentForm.vue
@@ -175,9 +175,21 @@
   >
     <!-- Fix for bug in Chrome where the username and password are mapped to non-login fields
      even if the HTML5 autocomplete attributes are set to the right values -->
-    <input type="text" class="d-none" id="username" v-model="credentials.email" autocomplete="username" />
-    <input type="password" class="d-none" id="password" v-model="credentials.password" autocomplete="new-password" />
-  
+    <input
+      type="text"
+      class="d-none"
+      id="username"
+      v-model="credentials.email"
+      autocomplete="username"
+    />
+    <input
+      type="password"
+      class="d-none"
+      id="password"
+      v-model="credentials.password"
+      autocomplete="new-password"
+    />
+
     <div v-if="errors.length" class="step-errors">
       <h5>Please correct the following problems:</h5>
       <ul>
@@ -549,6 +561,6 @@ export default {
 }
 
 .d-none {
-  display: none !important
+  display: none !important;
 }
 </style>

--- a/src/views/SignupView/StudentForm.vue
+++ b/src/views/SignupView/StudentForm.vue
@@ -173,9 +173,10 @@
     class="uc-form-body"
     @submit.prevent="submit()"
   >
-    <!-- Fix for bug in Chrome where the username and password are filled in to non-login fields
+    <!-- Fix for bug in Chrome where the username and password are mapped to non-login fields
      even if the HTML5 autocomplete attributes are set to the right values -->
-    <input type="password" class="d-none" id="password" name="fakepassword" autocomplete="new-password" />
+    <input type="text" class="d-none" id="username" v-model="credentials.email" autocomplete="username" />
+    <input type="password" class="d-none" id="password" v-model="credentials.password" autocomplete="new-password" />
   
     <div v-if="errors.length" class="step-errors">
       <h5>Please correct the following problems:</h5>

--- a/src/views/SignupView/StudentForm.vue
+++ b/src/views/SignupView/StudentForm.vue
@@ -132,6 +132,7 @@
         v-model="credentials.email"
         required
         autofocus
+        autocomplete="email"
       />
       <p class="uc-form-subtext">
         We will only use your email to contact you about your account. See our
@@ -152,6 +153,7 @@
         }"
         v-model="credentials.password"
         required
+        autocomplete="new-password"
       />
       <p class="uc-form-subtext">
         Keep your account safe by choosing a password with one number, one
@@ -171,6 +173,10 @@
     class="uc-form-body"
     @submit.prevent="submit()"
   >
+    <!-- Fix for bug in Chrome where the username and password are filled in to non-login fields
+     even if the HTML5 autocomplete attributes are set to the right values -->
+    <input type="password" class="d-none" id="password" name="fakepassword" autocomplete="new-password" />
+  
     <div v-if="errors.length" class="step-errors">
       <h5>Please correct the following problems:</h5>
       <ul>
@@ -192,6 +198,7 @@
         v-model="profile.firstName"
         required
         autofocus
+        autocomplete="given-name"
       />
     </div>
 
@@ -206,6 +213,7 @@
         }"
         v-model="profile.lastName"
         required
+        autocomplete="family-name"
       />
     </div>
 
@@ -537,5 +545,9 @@ export default {
       text-decoration: underline;
     }
   }
+}
+
+.d-none {
+  display: none !important
 }
 </style>

--- a/src/views/SignupView/VolunteerForm/VolunteerSignupForm.vue
+++ b/src/views/SignupView/VolunteerForm/VolunteerSignupForm.vue
@@ -69,6 +69,10 @@
 
     <div class="step-title">Step 2 of 2: Tell us about yourself!</div>
 
+    <!-- Fix for bug in Chrome where the username and password are filled in to non-login fields
+     even if the HTML5 autocomplete attributes are set to the right values -->
+    <input type="password" class="d-none" id="password" name="fakepassword" autocomplete="new-password" />
+
     <div class="uc-column">
       <label for="firstName" class="uc-form-label">First Name</label>
       <input
@@ -81,6 +85,7 @@
         v-model="profile.firstName"
         required
         autofocus
+        autocomplete="given-name"
       />
     </div>
 
@@ -95,6 +100,7 @@
         }"
         v-model="profile.lastName"
         required
+        autocomplete="family-name"
       />
     </div>
 
@@ -327,5 +333,9 @@ export default {
   color: #bf0000;
   font-size: 14px;
   text-align: left;
+}
+
+.d-none {
+  display: none !important
 }
 </style>

--- a/src/views/SignupView/VolunteerForm/VolunteerSignupForm.vue
+++ b/src/views/SignupView/VolunteerForm/VolunteerSignupForm.vue
@@ -73,8 +73,20 @@
 
     <!-- Fix for bug in Chrome where the first two fields are parsed as a username and password
      even if the HTML5 autocomplete attributes are set to the right values -->
-    <input type="text" class="d-none" id="username" v-model="credentials.email" autocomplete="username" />
-    <input type="password" class="d-none" id="password" v-model="credentials.password" autocomplete="new-password" />
+    <input
+      type="text"
+      class="d-none"
+      id="username"
+      v-model="credentials.email"
+      autocomplete="username"
+    />
+    <input
+      type="password"
+      class="d-none"
+      id="password"
+      v-model="credentials.password"
+      autocomplete="new-password"
+    />
 
     <div class="uc-column">
       <label for="firstName" class="uc-form-label">First Name</label>
@@ -339,6 +351,6 @@ export default {
 }
 
 .d-none {
-  display: none !important
+  display: none !important;
 }
 </style>

--- a/src/views/SignupView/VolunteerForm/VolunteerSignupForm.vue
+++ b/src/views/SignupView/VolunteerForm/VolunteerSignupForm.vue
@@ -21,6 +21,7 @@
         v-model="credentials.email"
         required
         autofocus
+        autocomplete="email"
       />
       <p class="uc-form-subtext">
         We will only use your email to contact you about your account. See our
@@ -41,6 +42,7 @@
         }"
         v-model="credentials.password"
         required
+        autocomplete="new-password"
       />
       <p class="uc-form-subtext">
         Keep your account safe by choosing a password with one number, one
@@ -69,9 +71,10 @@
 
     <div class="step-title">Step 2 of 2: Tell us about yourself!</div>
 
-    <!-- Fix for bug in Chrome where the username and password are filled in to non-login fields
+    <!-- Fix for bug in Chrome where the first two fields are parsed as a username and password
      even if the HTML5 autocomplete attributes are set to the right values -->
-    <input type="password" class="d-none" id="password" name="fakepassword" autocomplete="new-password" />
+    <input type="text" class="d-none" id="username" v-model="credentials.email" autocomplete="username" />
+    <input type="password" class="d-none" id="password" v-model="credentials.password" autocomplete="new-password" />
 
     <div class="uc-column">
       <label for="firstName" class="uc-form-label">First Name</label>

--- a/src/views/SignupView/VolunteerForm/VolunteerSignupForm.vue
+++ b/src/views/SignupView/VolunteerForm/VolunteerSignupForm.vue
@@ -71,24 +71,26 @@
 
     <div class="step-title">Step 2 of 2: Tell us about yourself!</div>
 
-    <!-- Fix for bug in Chrome where the first two fields are parsed as a username and password
-     even if the HTML5 autocomplete attributes are set to the right values -->
-    <input
-      type="text"
-      class="d-none"
-      id="username"
-      v-model="credentials.email"
-      autocomplete="username"
-    />
-    <input
-      type="password"
-      class="d-none"
-      id="password"
-      v-model="credentials.password"
-      autocomplete="new-password"
-    />
-
     <div class="uc-column">
+      <!-- Fix for bug in Chrome where the first two fields are parsed as a username and password
+       even if the HTML5 autocomplete attributes are set to the right values -->
+      <label for="username" class="d-none">Username</label>
+      <input
+        type="text"
+        class="d-none"
+        id="username"
+        v-model="credentials.email"
+        autocomplete="username"
+      />
+      <label for="password" class="d-none">Password</label>
+      <input
+        type="password"
+        class="d-none"
+        id="password"
+        v-model="credentials.password"
+        autocomplete="new-password"
+      />
+
       <label for="firstName" class="uc-form-label">First Name</label>
       <input
         id="firstName"


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/After-signup-Chrome-offers-to-save-your-login-details-Currently-it-s-not-parsing-the-correct-fiel-088307a7524a49e289ac6827b5fe0fe1

Description
-----------
When a new user proceeds to the page where they enter their first and last name, Chrome interprets the first name and last name fields as a username and password, and offers to save the username and password. It saves the first name as the username and the last name as the password. This issue appears to be a result of the way that Chrome tries to automatically interpret text fields as username and password fields.

This PR uses HTML5's `autocomplete` attribute to try to tell the browser what kinds of data the fields actually represent. It also tries to convince Chrome of the correct username and password to save by including the email and password as a pair of a text and password field hidden by a CSS class, so that Chrome's password manager should recognize the correct information. ~~This seems to work except for when a volunteer first signs up after entering the code; for some reason in this particular edge case Chrome still sets the first name as the username, but fortunately recognizes the correct password field.~~ (fixed by 5ecd668) The heuristics that Chrome uses to determine which fields are username and password fields are complex, so it will be very difficult to ensure that this bug is fixed for all possible edge cases; however, in the current state the behavior appears correct for all of the cases that I have tried in both Chrome and Firefox.

Developer self-review checklist
-------------------------------
- [ ] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested (on multiple browsers)
- [x] All new code complies with our ESLint standards
