### PR TITLE
Make sure user.verified is persisted in storage upon confirmation

### DIFF
--- a/src/services/OnboardingService.js
+++ b/src/services/OnboardingService.js
@@ -1,4 +1,5 @@
 import UserService from "./UserService";
+import AuthService from "./AuthService";
 import NetworkService from "./NetworkService";
 
 import router from "@/router";
@@ -22,6 +23,7 @@ export default {
       .then(() => {
         const user = UserService.getUser();
         user.verified = true;
+        AuthService.storeUser(user);
         router.replace("/");
       })
       .catch(() => {


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Volunteer-scheduling-system-audit-88e77bfa48bb421b8bcb3e916e38c7b7

Description
-----------
Currently, when a user clicks on the verification link for signup, the onboarding service sets `user.verified = true` but does not update the locally-stored user object. Ultimately, we would like to remove all dependence on `localStorage` for storing the user object on the client-side, but for now this PR fixes the behavior by updating the locally-stored user object after `verified = true` has been set.

Developer self-review checklist
-------------------------------
- [ ] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested (on multiple browsers)
- [x] All new code complies with our ESLint standards
