### PR TITLE
Connect socket only when authenticated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6103,7 +6103,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6121,11 +6122,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6138,15 +6141,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6249,7 +6255,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6259,6 +6266,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6271,17 +6279,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6298,6 +6309,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6370,7 +6382,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6380,6 +6393,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6455,7 +6469,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6485,6 +6500,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6502,6 +6518,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6540,11 +6557,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -7439,7 +7458,8 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "optional": true
         },
         "figures": {
           "version": "2.0.0",
@@ -7470,6 +7490,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -12334,7 +12355,8 @@
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
@@ -13500,7 +13522,8 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ import VueHeadful from "vue-headful";
 import vSelect from "vue-select";
 import VuePhoneNumberInput from "vue-phone-number-input";
 
+import Socket from "socket.io-client";
+
 import App from "./components/App";
 import router from "./router";
 import store from "./store";
@@ -13,7 +15,10 @@ import store from "./store";
 Vue.config.productionTip = false;
 
 // Use plugins
-Vue.use(VueSocketIO, process.env.VUE_APP_SOCKET_ADDRESS);
+const socket = Socket(process.env.VUE_APP_SOCKET_ADDRESS, {
+  autoConnect: false
+});
+Vue.use(VueSocketIO, socket);
 Vue.use(VueRouter);
 
 // Set up vue-headful

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -28,6 +28,9 @@ export default {
         AnalyticsService.identify(data.user, data.user.isFakeUser);
         AnalyticsService.trackNoProperties("logged in", data.user.isFakeUser);
 
+        // connect socket
+        context.$socket.connect();
+        
         return data;
       },
       () => {
@@ -106,6 +109,10 @@ export default {
         .catch(() => {
           context.$store.dispatch("user/clearUser");
           context.$router.push("/logout");
+        })
+        .finally(() => {
+          // disconnect socket
+          context.$socket.disconnect();
         });
     }
   },

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -30,7 +30,7 @@ export default {
 
         // connect socket
         context.$socket.connect();
-        
+
         return data;
       },
       () => {


### PR DESCRIPTION
Links
-----
- Task: https://www.notion.so/upchieve/Session-Controller-Twilio-service-refactor-ecd838c592db4d4a8c074713a8f2bb13
- Server repo PR: https://github.com/UPchieve/server/pull/156

Description
-----------
The passport socket.io authentication in https://github.com/UPchieve/server/pull/156, in order to work properly, requires the socket connection to be established only after authentication. This PR connects the socket when the user logs in and disconnects when the user logs out.

Developer self-review checklist
-------------------------------
- [x] Task's requirements have been fully addressed
- [x] Potentially confusing code has been explained with comments
- [x] Posted a link to this PR on the Notion task
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [x] Branch has been deployed to staging, and all edge cases have been manually tested (on multiple browsers)
- [x] All new code complies with our ESLint standards
