### PR TITLE
Math-Only Partner Orgs

### DIFF
--- a/src/views/OrgSignupView.vue
+++ b/src/views/OrgSignupView.vue
@@ -261,7 +261,7 @@ export default {
 
     isValidOrgEmail(email) {
       const requiredDomains = this.orgManifest.requiredEmailDomains;
-      if (!(requiredDomains && requiredDomains.length)) return false;
+      if (!(requiredDomains && requiredDomains.length)) return true;
 
       const domain = email.split("@")[1];
       return domain && requiredDomains.indexOf(domain) >= 0;

--- a/src/views/TrainingView.vue
+++ b/src/views/TrainingView.vue
@@ -63,6 +63,7 @@
 </template>
 
 <script>
+import _ from "lodash";
 import { mapState } from "vuex";
 
 import { topics, allSubtopics } from "@/utils/topics";
@@ -82,17 +83,6 @@ export default {
         result[key] = value;
         return result;
       }, {});
-
-    const supercategoryMenuDisplayStates = Object.entries(topics)
-      .map(([, topicObj]) => topicObj.displayName)
-      .reduce((result, key) => {
-        result[key] = false;
-        return result;
-      }, {});
-
-    const supercategories = Object.entries(topics).map(
-      ([, topicObj]) => topicObj.displayName
-    );
 
     // todo consider refactoring so that we identify categories by the
     // key rather than by the display name
@@ -128,18 +118,49 @@ export default {
       "https://drive.google.com/open?id=1lJXVI1f9Do60pNXcBQGSZThNXhYmtMvV";
     reviewMaterials.applications =
       "https://drive.google.com/open?id=1gXmbGRaUz324-EiZMzph1KUYS8WhR9ax";
+
     return {
       quizzes,
-      supercategoryMenuDisplayStates,
-      supercategories,
       supercategoryColors,
       reviewMaterials,
-      categoryKeys
+      categoryKeys,
+      supercategoryMenuDisplayStates: {}
     };
   },
-  computed: {
-    ...mapState({ user: state => state.user.user })
+
+  created() {
+    const displayStates = Object.entries(this.topicsToDisplay)
+      .map(([, topicObj]) => topicObj.displayName)
+      .reduce((result, key) => {
+        result[key] = false;
+        return result;
+      }, {});
+
+    // If there's only 1 supercategory, open the collapsible by default
+    if (_.size(displayStates) === 1) {
+      const singleSupercategoryKey = Object.keys(displayStates)[0];
+      displayStates[singleSupercategoryKey] = true;
+    }
+
+    this.supercategoryMenuDisplayStates = displayStates;
   },
+
+  computed: {
+    ...mapState({ user: state => state.user.user }),
+
+    topicsToDisplay() {
+      return this.user.mathCoachingOnly
+        ? _.pick(topics, 'math')
+        : topics;
+    },
+
+    supercategories() {
+      return Object.entries(this.topicsToDisplay).map(
+        ([, topicObj]) => topicObj.displayName
+      );
+    }
+  },
+
   methods: {
     toggleSupercategoryShown(supercategory) {
       const isShown = this.supercategoryMenuDisplayStates[supercategory];

--- a/src/views/TrainingView.vue
+++ b/src/views/TrainingView.vue
@@ -149,6 +149,7 @@ export default {
     ...mapState({ user: state => state.user.user }),
 
     topicsToDisplay() {
+      // Only display math topics to certain flagged volunteers
       return this.user.mathCoachingOnly ? _.pick(topics, "math") : topics;
     },
 

--- a/src/views/TrainingView.vue
+++ b/src/views/TrainingView.vue
@@ -149,9 +149,7 @@ export default {
     ...mapState({ user: state => state.user.user }),
 
     topicsToDisplay() {
-      return this.user.mathCoachingOnly
-        ? _.pick(topics, 'math')
-        : topics;
+      return this.user.mathCoachingOnly ? _.pick(topics, "math") : topics;
     },
 
     supercategories() {


### PR DESCRIPTION
Links
-----
- Server repo PR: https://github.com/UPchieve/server/pull/161

Description
-----------
- Add support for restricting certain volunteers to math tutoring (no college counseling)


_Note_: This is a bit hacky & not generalized to allow any/all topics to be blacklisted, but:
- we're under a time crunch
- the training view needs major refactoring -- it's not worth wrestling with right now
- restrictions by coaching topic likely won't be a common demand of partner orgs in the near future

Developer self-review checklist
-------------------------------
- [ ] Task's requirements have been fully addressed
- [ ] Potentially confusing code has been explained with comments
- [ ] Posted a link to this PR on the Notion task
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] There are no new spelling/grammar mistakes in the UI, code, or documentation
- [ ] Branch has been deployed to staging, and all edge cases have been manually tested (on multiple browsers)
- [ ] All new code complies with our ESLint standards
