### PR TITLE
Load user profile with statistics for dashboard

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -32,14 +32,14 @@ import { topics } from "./utils/topics";
 Vue.use(VueResource);
 Vue.http.options.credentials = true;
 
-const getUser = () => {
+const getUser = withStats => {
   if (store.getters["user/isAuthenticated"]) {
     return new Promise(resolve => {
-      store.dispatch("user/fetchUser");
+      store.dispatch("user/fetchUser", { withStats: !!withStats });
       resolve();
     });
   } else {
-    return store.dispatch("user/fetchUser");
+    return store.dispatch("user/fetchUser", { withStats: !!withStats });
   }
 };
 
@@ -106,7 +106,11 @@ const routes = [
     path: "/dashboard",
     name: "DashboardView",
     component: DashboardView,
-    meta: { protected: true }
+    meta: { protected: true },
+    beforeEnter: (to, from, next) => {
+      // ensure stats are displayed on dashboard
+      getUser(true).then(() => next());
+    }
   },
   {
     path: "/session/:topic/:subTopic/:sessionId?",

--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -118,12 +118,14 @@ export default {
   },
 
   getAuth(context, options) {
-    const isGlobal = options && options.isGlobal;
+    const { isGlobal, withStats } = options
+      ? options
+      : { isGlobal: false, withStats: false };
 
     const authPromise =
       !context || isGlobal
-        ? NetworkService.userGlobal(Vue)
-        : NetworkService.user(context);
+        ? NetworkService.userGlobal(Vue, withStats)
+        : NetworkService.user(context, withStats);
     return authPromise
       .then(res => {
         const data = { ...res.data };

--- a/src/services/NetworkService.js
+++ b/src/services/NetworkService.js
@@ -54,14 +54,14 @@ export default {
       .post(`${AUTH_ROOT}/reset/confirm`, data)
       .then(this._successHandler, this._errorHandler);
   },
-  user(context) {
+  user(context, withStats) {
     return context.$http
-      .get(`${API_ROOT}/user`)
+      .get(`${API_ROOT}/user?withStats=${withStats}`)
       .then(this._successHandler, this._errorHandler);
   },
-  userGlobal(Vue) {
+  userGlobal(Vue, withStats) {
     return Vue.http
-      .get(`${API_ROOT}/user`)
+      .get(`${API_ROOT}/user?withStats=${withStats}`)
       .then(this._successHandler, this._errorHandler);
   },
   sendVerification(context) {

--- a/src/services/UserService.js
+++ b/src/services/UserService.js
@@ -4,11 +4,11 @@ import AuthService from "./AuthService";
 import OnboardingService from "./OnboardingService";
 
 export default {
-  getAuth(context) {
-    return AuthService.getAuth(context);
+  getAuth(context, options) {
+    return AuthService.getAuth(context, options);
   },
-  getUser(context) {
-    return this.getAuth(context).then(auth => {
+  getUser(context, withStats) {
+    return this.getAuth(context, { withStats }).then(auth => {
       if (auth.authenticated) {
         return auth.user;
       }

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -15,12 +15,14 @@ export default {
   },
   actions: {
     fetch: ({ dispatch }, context) => {
-      dispatch("fetchUser");
+      dispatch("fetchUser", { withStats: false });
       dispatch("fetchSession", context);
     },
 
-    fetchUser: ({ commit }) => {
-      return UserService.getUser().then(user => commit("setUser", user));
+    fetchUser: ({ commit }, options) => {
+      return UserService.getUser(null, !!(options && options.withStats)).then(
+        user => commit("setUser", user)
+      );
     },
 
     clearUser: ({ commit }) => {

--- a/src/views/DashboardView/VolunteerDashboard/index.vue
+++ b/src/views/DashboardView/VolunteerDashboard/index.vue
@@ -153,7 +153,10 @@ export default {
         },
         {
           label: "Hours of tutoring completed",
-          value: `${numHoursTutored} hours tutored`
+          value:
+            numHoursTutored !== null
+              ? `${numHoursTutored} hours tutored`
+              : "Computing..."
         }
       ];
     }


### PR DESCRIPTION
Links
-----
- Issue: #284
- Server repo PR: https://github.com/UPchieve/server/pull/175

Description
-----------
- Only load volunteer statistics when the dashboard route is reached; don't have the server compute the statistics for every time the `/api/user` endpoint is reached.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
