### PR TITLE
Sticky header footer mobile

### DIFF
--- a/src/views/SessionView/SessionChat/index.vue
+++ b/src/views/SessionView/SessionChat/index.vue
@@ -365,7 +365,7 @@ span {
     width: calc(100% - 100px);
     height: 40px;
     border: none;
-    position: absolute;
+    position: fixed;
     left: 0;
     bottom: 0;
     border: 1px solid #d6e0ef;

--- a/src/views/SessionView/Whiteboard.vue
+++ b/src/views/SessionView/Whiteboard.vue
@@ -600,11 +600,15 @@ canvas {
   display: flex;
   align-items: center;
   flex-direction: column;
-  position: absolute;
+  position: fixed;
   bottom: 20px;
   border-radius: 8px;
   left: 50%;
   transform: translate(-50%, 0);
+
+  @include breakpoint-above("medium") {
+    position: absolute;
+  }
 
   .mobile-whiteboard-notice {
     margin: auto;

--- a/src/views/SessionView/index.vue
+++ b/src/views/SessionView/index.vue
@@ -214,7 +214,7 @@ export default {
 }
 
 .session-header-container {
-  position: absolute;
+  position: fixed;
   z-index: 3;
   top: 0;
   left: 0;
@@ -222,6 +222,7 @@ export default {
   background: #fff;
 
   @include breakpoint-above("medium") {
+    position: absolute;
     top: 20px;
     left: unset;
     right: 20px;
@@ -303,7 +304,7 @@ export default {
 }
 
 .toggleButton {
-  position: absolute;
+  position: fixed;
   z-index: 3;
   bottom: 10px;
   right: 20px;

--- a/src/views/SessionView/index.vue
+++ b/src/views/SessionView/index.vue
@@ -322,6 +322,6 @@ export default {
 }
 
 .toggleButton.back {
-  bottom: calc(100vh - 140px);
+  bottom: calc(100% - 140px);
 }
 </style>


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/288

Description
-----------
- Fix issue with mobile safari scrolling that caused session's header & footer to be non-sticky sometimes
- Basically, for mobile view use fixed positioning instead of absolute, and don't rely on `vh` units

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
