### PR TITLE
Fix volunteer timezone conversion

### DIFF
--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -109,9 +109,7 @@ export default {
       this.selectedTz = hasValidTimezone ? userTimezone : moment.tz.guess();
 
       const originalAvailability = this.user.availability;
-      var estUtcOffset = moment.tz
-        .zone("America/New_York")
-        .parse(Date.now());
+      var estUtcOffset = moment.tz.zone("America/New_York").parse(Date.now());
       var userUtcOffset = moment.tz.zone(this.selectedTz).parse(Date.now());
       var offset = (estUtcOffset - userUtcOffset) / 60;
       this.availability = this.convertAvailability(

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -122,7 +122,9 @@ export default {
             this.selectedTz = moment.tz.guess();
           }
 
-          var estUtcOffset = moment.tz.zone("America/New_York").parse(Date.now());
+          var estUtcOffset = moment.tz
+            .zone("America/New_York")
+            .parse(Date.now());
           var userUtcOffset = moment.tz.zone(this.selectedTz).parse(Date.now());
           var offset = (estUtcOffset - userUtcOffset) / 60;
           this.availability = this.convertAvailability(

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -239,9 +239,10 @@ export default {
       return convertedAvailability;
     },
     save() {
-      var estNow = moment.tz("America/New_York").hour();
-      var userNow = moment.tz(this.selectedTz).hour();
-      var offset = estNow - userNow;
+      const estUtcOffset = moment.tz.zone("America/New_York").parse(Date.now());
+      const userUtcOffset = moment.tz.zone(this.selectedTz).parse(Date.now());
+      // offsets returned by zone.utcOffset() are returned in minutes and inverted for POSIX compatibility
+      const offset = (userUtcOffset - estUtcOffset) / 60;
       CalendarService.updateTimezone(this, this.user._id, this.selectedTz);
       CalendarService.updateAvailability(
         this,

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -122,9 +122,9 @@ export default {
             this.selectedTz = moment.tz.guess();
           }
 
-          var estNow = moment.tz("America/New_York").hour();
-          var userNow = moment.tz(this.selectedTz).hour();
-          var offset = userNow - estNow;
+          var estUtcOffset = moment.tz.zone("America/New_York").parse(Date.now());
+          var userUtcOffset = moment.tz.zone(this.selectedTz).parse(Date.now());
+          var offset = (estUtcOffset - userUtcOffset) / 60;
           this.availability = this.convertAvailability(
             originalAvailability,
             offset


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/292

Description
-----------
- The current timezone conversion logic relies on the hour of the current time in the different timezones to try to calculate the offset. However, this breaks when the calendar date is different in the different time zones. For example, on Friday, January 3, 2020 at 22:00 in California it was Saturday, January 4, 2020 at 01:00 in New York; the code would take the difference between the hours 1 - 22 = -21 and use that offset instead of the correct one (+3) to convert the availability hours.
- This PR changes the logic to use the `parse` function in the zone object to obtain the current offsets for each timezone, rather than trying to determine it from the hours.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
