### PR TITLE
fix e2e tests

### DIFF
--- a/tests/e2e/specs/student-tests.js
+++ b/tests/e2e/specs/student-tests.js
@@ -22,10 +22,13 @@ describe("Student tests", () => {
   });
 
   it("Should log out successfully", () => {
-    cy.get("a")
-      .contains("Logout")
+    cy.get("body")
+      .contains("Log out")
       .click();
 
-    cy.location("pathname").should("eq", "/logout");
+    cy.get("body", { timeout: 50000 }).should($p => {
+      expect($p.first()).to.contain("logged out");
+    });
+    //cy.location("pathname", { timeout: 5000 }).should("eq", "/logout");
   });
 });


### PR DESCRIPTION
Links
-----
- Issue: 1 of 2 e2e tests currently run

Description
-----------
- Logout link was incorrectly identified, and a default timeout was too short for logout on my local machine.

Developer self-review checklist
-------------------------------

