### PR TITLE
Fix MathJax rendering issues

### DIFF
--- a/src/views/QuizView.vue
+++ b/src/views/QuizView.vue
@@ -271,9 +271,9 @@ export default {
         return;
       }
 
-      MathJax.Hub.Queue(
-        ["Typeset", MathJax.Hub, questionText],
-        ["Typeset", MathJax.Hub, answerChoices]
+      window.MathJax.Hub.Queue(
+        ["Typeset", window.MathJax.Hub, questionText],
+        ["Typeset", window.MathJax.Hub, answerChoices]
       );
     },
     reload() {

--- a/src/views/QuizView.vue
+++ b/src/views/QuizView.vue
@@ -239,6 +239,14 @@ export default {
     this.rerenderMathJaxElements();
   },
   methods: {
+    /**
+     * TODO:
+     * for stuff that has regular text after some MathJax,
+     * causes problems with multiple innerTexts after removing inner el's
+     * --
+     * so, instead of deleting the MathJax el's, try just clearing all the
+     * innerHTML of the quiz options + question text
+     */
     clearMathJaxElements() {
       const quizBody = document.querySelector(".quizBody");
 

--- a/src/views/QuizView.vue
+++ b/src/views/QuizView.vue
@@ -237,34 +237,34 @@ export default {
     this.rerenderMathJaxElements();
   },
   methods: {
-    /**
-     * TODO:
-     * for stuff that has regular text after some MathJax,
-     * causes problems with multiple innerTexts after removing inner el's
-     * --
-     * so, instead of deleting the MathJax el's, try just clearing all the
-     * innerHTML of the quiz options + question text
-     */
     clearMathJaxElements() {
       const quizBody = document.querySelector(".quizBody");
 
       // Remove any MathJax-rendered elements from the DOM.
       // Do this before updating to avoid rendering artifacts being left behind
-      const mathJaxElements = quizBody.querySelectorAll(
-        "[class*=mjx],[class*=MathJax],[id*=MathJax]"
+      const mathJaxElements = Array.from(
+        quizBody.querySelectorAll("[class*=mjx],[class*=MathJax],[id*=MathJax]")
       );
-      Array.from(mathJaxElements).forEach(e => e.remove());
+
+      const mathJaxParentElements = Array.from(
+        quizBody.querySelectorAll(".MathJax_Preview")
+      ).map(e => e.parentElement);
+
+      mathJaxElements.forEach(e => e.remove());
 
       // MathJax slices up the DOM nodes it renders as math formulas. We need to
       // rejoin these under the first child's data attribute to avoid artifacts
       // being left behind
-      const questionText = quizBody.querySelector(".questionText");
-      questionText.firstChild.data = questionText.innerText;
+      mathJaxParentElements.forEach(parentEl => {
+        if (!(parentEl && parentEl.firstChild)) return;
 
-      // Remove all child nodes but the first
-      Array.from(questionText.childNodes)
-        .slice(1)
-        .forEach(e => e.remove());
+        parentEl.firstChild.data = parentEl.innerText;
+
+        // Remove all child nodes but the first
+        Array.from(parentEl.childNodes)
+          .slice(1)
+          .forEach(e => e.remove());
+      });
     },
 
     rerenderMathJaxElements() {

--- a/src/views/QuizView.vue
+++ b/src/views/QuizView.vue
@@ -165,8 +165,6 @@ import { mapState } from "vuex";
 
 import TrainingService from "@/services/TrainingService";
 
-const MathJax = window.MathJax;
-
 /**
  * @note {1} Why the extra parens: https://stackoverflow.com/a/27386370
  */


### PR DESCRIPTION
Description
-----------
- Reference MathJax library via explicit `window` instead of implied global (I'm not positive why this was a problem, but it fixed an issue on my local machine where MathJax wasn't working at all)
- Fix issue where quiz options which had MathJax expressions that were sandwiched between two sections of plain text would cause the trailing section of plain text to be appended to later quiz question options.
   - e.g. if a question's "b." option was `d\( \sqrt{3} \)  and d\( \sqrt{2} \)`, all future "b." options would have "and d" appended to them.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
