### PR TITLE
Only execute drawEnd on mouse leave if the user is drawing something

### DIFF
--- a/src/views/SessionView/Whiteboard.vue
+++ b/src/views/SessionView/Whiteboard.vue
@@ -7,7 +7,7 @@
         @mousedown="drawStart"
         @mousemove="draw"
         @mouseup="drawEnd"
-        @mouseleave="drawEnd"
+        @mouseleave="handleMouseLeave"
         width="1600"
         height="1200"
       />
@@ -250,6 +250,11 @@ export default {
       imageList = [];
       saveImage(App.canvas, App.ctx);
       this.emitClearClick();
+    },
+    handleMouseLeave(event) {
+      if (App.canvas.isDrawing) {
+        this.drawEnd(event);
+      }
     },
     drawStart(event) {
       if (this.mobileMode) {


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/297

Description
-----------
- Instead of simply calling `drawEnd` every time the user's mouse leaves the canvas and potentially saving a blank canvas to the server, `drawEnd` will only be called if the user was actually drawing something when the mouse left the canvas.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
