### PR TITLE
Remove userid from calendar and quiz request bodies

### DIFF
--- a/src/services/CalendarService.js
+++ b/src/services/CalendarService.js
@@ -1,12 +1,12 @@
 import NetworkService from "./NetworkService";
 
 export default {
-  updateAvailability(context, userid, availability) {
+  updateAvailability(context, availability) {
     context.$store.dispatch("user/updateAvailability", availability);
-    return NetworkService.updateAvailability(context, { userid, availability });
+    return NetworkService.updateAvailability(context, { availability });
   },
-  updateTimezone(context, userid, tz) {
+  updateTimezone(context, tz) {
     context.$store.dispatch("user/updateTimezone", tz);
-    return NetworkService.updateTimezone(context, { userid, tz });
+    return NetworkService.updateTimezone(context, { tz });
   }
 };

--- a/src/services/TrainingService.js
+++ b/src/services/TrainingService.js
@@ -69,9 +69,8 @@ export default {
     }
     this.idAnswerMap[question._id] = picked;
   },
-  submitQuiz(context, userid) {
+  submitQuiz(context) {
     return NetworkService.getQuizScore(context, {
-      userid,
       idAnswerMap: this.idAnswerMap,
       category: this.category
     }).then(res => {

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -255,10 +255,9 @@ export default {
       const userUtcOffset = moment.tz.zone(this.selectedTz).parse(Date.now());
       // offsets returned by zone.utcOffset() are returned in minutes and inverted for POSIX compatibility
       const offset = (userUtcOffset - estUtcOffset) / 60;
-      CalendarService.updateTimezone(this, this.user._id, this.selectedTz);
+      CalendarService.updateTimezone(this, this.selectedTz);
       CalendarService.updateAvailability(
         this,
-        this.user._id,
         this.convertAvailability(this.availability, offset)
       ).then(response => {
         if (response.status == 200) {

--- a/src/views/QuizView.vue
+++ b/src/views/QuizView.vue
@@ -365,7 +365,7 @@ export default {
     submit() {
       TrainingService.saveAnswer(this, this.picked);
       if (TrainingService.hasCompleted()) {
-        TrainingService.submitQuiz(this, this.user._id).then(data => {
+        TrainingService.submitQuiz(this).then(data => {
           if (data.passed) {
             this.passedMsg = "You passed!";
             this.showDone = true;


### PR DESCRIPTION
Links
-----

Description
-----------
- The calendar and training services are updated so that they no longer send the user ID in the body of the HTTP requests.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
