### PR TITLE
Login and logout commands for e2e tests of authenticated views

### DIFF
--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -14,6 +14,14 @@ module.exports = (on, config) => {
   //  watchOptions: {}
   // }))
 
+  // import Vue CLI environment variables into Cypress
+  // original code at https://github.com/vuejs/vue-cli/issues/2447
+  Object.entries(process.env)
+    .filter(([key]) => key.startsWith("VUE_APP"))
+    .forEach(([key, value]) => {
+      config.env[key.replace("VUE_APP_", "")] = value;
+    });
+
   return Object.assign({}, config, {
     fixturesFolder: "tests/e2e/fixtures",
     integrationFolder: "tests/e2e/specs",

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -23,3 +23,22 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+const AUTH_ROOT = `${Cypress.env("SERVER_ROOT")}/auth`;
+
+Cypress.Commands.add("login", user => {
+  cy.request({
+    method: "POST",
+    url: `${AUTH_ROOT}/login`,
+    body: {
+      email: user.email,
+      password: user.password
+    }
+  });
+});
+
+Cypress.Commands.add("logout", () => {
+  cy.request({
+    url: `${AUTH_ROOT}/logout`
+  });
+});


### PR DESCRIPTION
Links
-----

Description
-----------
- New Cypress commands `login` and `logout` are added to send the appropriate REST API requests to authenticate the test users. These commands will allow other use cases besides logging in and out to be tested in isolation.
- Vue CLI environment variables are imported into Cypress via plugins. (See https://github.com/vuejs/vue-cli/issues/2447 for the proposition to add this into the Vue CLI.)

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
