### PR TITLE
Only fetch session if user is authenticated

### DIFF
--- a/src/components/App/index.vue
+++ b/src/components/App/index.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import { mapState } from "vuex";
+import { mapState, mapGetters } from "vuex";
 
 import SessionService from "@/services/SessionService";
 
@@ -39,7 +39,9 @@ export default {
     this.handleResize();
   },
   beforeUpdate() {
-    this.$store.dispatch("user/fetchSession", this);
+    if (this.userAuthenticated) {
+      this.$store.dispatch("user/fetchSession", this);
+    }
   },
   beforeDestroy() {
     window.removeEventListener("resize", this.handleResize);
@@ -57,6 +59,9 @@ export default {
       showHeader: state => state.app.header.isShown,
       showSidebar: state => state.app.sidebar.isShown,
       showModal: state => state.app.modal.isShown
+    }),
+    ...mapGetters({
+      userAuthenticated: "user/isAuthenticated"
     })
   },
   sockets: {


### PR DESCRIPTION
Links
-----
- Sentry issue: https://sentry.io/organizations/upchieve/issues/1461024444/?referrer=github_integration

Description
-----------
- The `App` component's `beforeUpdate` hook is updated so that it only tries to fetch the current session if there is an authenticated user. This will prevent unnecessary calls to `/api/session/current`.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
