### PR TITLE
Make calendar horizontally scrollable on mobile view

### DIFF
--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -405,19 +405,19 @@ input[type="checkbox"]:checked + label {
     padding-top: 0em !important;
     padding-bottom: 0em !important;
   }
-  
+
   .dayTimeScrollContainer {
     display: flex;
     align-items: flex-start;
     overflow-x: scroll;
   }
-  
+
   .calendar-container {
     width: 100%;
     position: absolute;
     overflow-x: hidden;
   }
-  
+
   input[type="checkbox"] {
     position: relative;
     margin-top: 0;

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -409,6 +409,13 @@ input[type="checkbox"]:checked + label {
 
   .calendar-container {
     width: 100%;
+    @each $key, $value in $app-sidebar-width-map {
+      @if map-get($breakpoint-map, $key) {
+        @include breakpoint-above($key) {
+          width: calc(100% - #{$value});
+        }
+      }
+    }
     position: absolute;
     overflow-x: hidden;
   }

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -400,7 +400,7 @@ input[type="checkbox"]:checked + label {
   padding-top: 30px;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: get-breakpoint("medium")) {
   .btn {
     padding-top: 0em !important;
     padding-bottom: 0em !important;

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -16,30 +16,32 @@
             </option>
           </select>
         </div>
-        <div class="dayTimeContainer">
-          <div class="timeLabelContainer">
-            <div v-for="time in timeRange" :key="time" class="timeLabel">
-              {{ time }}
-            </div>
-          </div>
-          <form class="dayTime">
-            <div v-for="(dayValue, day) in availability" :key="`day-${day}`">
-              <div class="dayLabel">{{ day }}</div>
-              <div class="times">
-                <div
-                  v-for="sortedTime in sortedTimes[day]"
-                  :key="sortedTime"
-                  class="timeOfDay"
-                >
-                  <input
-                    v-model="availability[day][sortedTime]"
-                    type="checkbox"
-                  />
-                  <label for="sortedTime" />
-                </div>
+        <div class="dayTimeScrollContainer">
+          <div class="dayTimeContainer">
+            <div class="timeLabelContainer">
+              <div v-for="time in timeRange" :key="time" class="timeLabel">
+                {{ time }}
               </div>
             </div>
-          </form>
+            <form class="dayTime">
+              <div v-for="(dayValue, day) in availability" :key="`day-${day}`">
+                <div class="dayLabel">{{ day }}</div>
+                <div class="times">
+                  <div
+                    v-for="sortedTime in sortedTimes[day]"
+                    :key="sortedTime"
+                    class="timeOfDay"
+                  >
+                    <input
+                      v-model="availability[day][sortedTime]"
+                      type="checkbox"
+                    />
+                    <label for="sortedTime" />
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
         </div>
       </div>
     </div>
@@ -402,6 +404,24 @@ input[type="checkbox"]:checked + label {
   .btn {
     padding-top: 0em !important;
     padding-bottom: 0em !important;
+  }
+  
+  .dayTimeScrollContainer {
+    display: flex;
+    align-items: flex-start;
+    overflow-x: scroll;
+  }
+  
+  .calendar-container {
+    width: 100%;
+    position: absolute;
+    overflow-x: hidden;
+  }
+  
+  input[type="checkbox"] {
+    position: relative;
+    margin-top: 0;
+    margin-bottom: -40px;
   }
 }
 </style>

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -400,7 +400,7 @@ input[type="checkbox"]:checked + label {
   padding-top: 30px;
 }
 
-@media screen and (max-width: #{get-app-sidebar-width("medium") + 1210px}) {
+@media screen and (max-width: #{get-app-sidebar-width("medium") + 960px}) {
   .dayTimeScrollContainer {
     display: flex;
     align-items: flex-start;

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -400,12 +400,7 @@ input[type="checkbox"]:checked + label {
   padding-top: 30px;
 }
 
-@media screen and (max-width: get-breakpoint("medium")) {
-  .btn {
-    padding-top: 0em !important;
-    padding-bottom: 0em !important;
-  }
-
+@media screen and (max-width: #{get-app-sidebar-width("medium") + 1210px}) {
   .dayTimeScrollContainer {
     display: flex;
     align-items: flex-start;
@@ -422,6 +417,13 @@ input[type="checkbox"]:checked + label {
     position: relative;
     margin-top: 0;
     margin-bottom: -40px;
+  }
+}
+
+@media screen and (max-width: get-breakpoint("medium")) {
+  .btn {
+    padding-top: 0em !important;
+    padding-bottom: 0em !important;
   }
 }
 </style>


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/312

Description
-----------
- The CSS media query for `min-width: 700px` in `CalendarView` is updated so that the date/time table becomes horizontally scrollable. The `dayTimeContainer` is placed into a new `div` so that the container can be scrolled to the left to reveal the times.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
