### PR TITLE
Clear session on logout

### DIFF
--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -103,11 +103,11 @@ export default {
     if (context) {
       NetworkService.logout(context)
         .then(() => {
-          context.$store.dispatch("user/clearUser");
+          context.$store.dispatch("user/clear");
           context.$router.push("/logout");
         })
         .catch(() => {
-          context.$store.dispatch("user/clearUser");
+          context.$store.dispatch("user/clear");
           context.$router.push("/logout");
         })
         .finally(() => {

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -63,14 +63,6 @@ export default {
       commit("setUser", {});
     },
 
-    updateAvailability: ({ commit }, availability, date = Date.now()) => {
-      commit("setAvailability", availability, date);
-    },
-
-    updateTimezone: ({ commit }, timezone, date = Date.now()) => {
-      commit("setTimezone", timezone, date);
-    },
-
     fetchSession: ({ commit, state }, context) => {
       SessionService.getCurrentSession(context, state.user)
         .then(({ sessionData }) => {
@@ -84,16 +76,24 @@ export default {
         });
     },
 
+    clearSession: ({ commit }) => {
+      commit("setSession", {});
+    },
+
     updateSession: ({ commit }, sessionData) => {
       commit("setSession", sessionData);
     },
 
-    addMessage: ({ commit }, message) => {
-      commit("addMessage", message);
+    updateAvailability: ({ commit }, availability, date = Date.now()) => {
+      commit("setAvailability", availability, date);
     },
 
-    clearSession: ({ commit }) => {
-      commit("setSession", {});
+    updateTimezone: ({ commit }, timezone, date = Date.now()) => {
+      commit("setTimezone", timezone, date);
+    },
+
+    addMessage: ({ commit }, message) => {
+      commit("addMessage", message);
     }
   },
   getters: {

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -50,6 +50,11 @@ export default {
       dispatch("fetchSession", context);
     },
 
+    clear: ({ commit }) => {
+      commit("setUser", {});
+      commit("setSession", {});
+    },
+
     fetchUser: ({ commit }) => {
       return UserService.getUser().then(user => commit("updateUser", user));
     },


### PR DESCRIPTION
Description
-----------
- On logout, clear session stored in Vuex
- Previously, when switching accounts during an active session, the first account's session would briefly be displayed in the second account (i.e. the orange top-bar saying "return to active session" would show up for a few seconds)
- Not a big issue for most of our users but it caused problems with e2e tests
- Additionally, I re-organized the user Vuex actions

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
