### PR TITLE
Send availability and timezone in combined API request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6156,7 +6156,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6174,11 +6175,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6191,15 +6194,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6302,7 +6308,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6312,6 +6319,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6324,17 +6332,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6351,6 +6362,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6423,7 +6435,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6433,6 +6446,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6508,7 +6522,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6538,6 +6553,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6555,6 +6571,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6593,11 +6610,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -7497,7 +7516,8 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "optional": true
         },
         "figures": {
           "version": "2.0.0",
@@ -7528,6 +7548,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -12329,7 +12350,8 @@
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
@@ -13495,7 +13517,8 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",

--- a/src/services/CalendarService.js
+++ b/src/services/CalendarService.js
@@ -1,12 +1,9 @@
 import NetworkService from "./NetworkService";
 
 export default {
-  updateAvailability(context, availability) {
+  updateSchedule(context, availability, tz) {
     context.$store.dispatch("user/updateAvailability", availability);
-    return NetworkService.updateAvailability(context, { availability });
-  },
-  updateTimezone(context, tz) {
     context.$store.dispatch("user/updateTimezone", tz);
-    return NetworkService.updateTimezone(context, { tz });
+    return NetworkService.updateSchedule(context, { availability, tz });
   }
 };

--- a/src/services/NetworkService.js
+++ b/src/services/NetworkService.js
@@ -124,7 +124,7 @@ export default {
       .post(`${API_ROOT}/training/score`, data)
       .then(this._successHandler, this._errorHandler);
   },
-  updateAvailability(context, data) {
+  updateSchedule(context, data) {
     return context.$http
       .post(`${API_ROOT}/calendar/save`, data)
       .then(this._successHandler, this._errorHandler);
@@ -147,11 +147,6 @@ export default {
   checkIfMessageIsClean(context, data) {
     return context.$http
       .post(`${API_ROOT}/moderate/message`, data)
-      .then(this._successHandler, this._errorHandler);
-  },
-  updateTimezone(context, data) {
-    return context.$http
-      .post(`${API_ROOT}/calendar/tz/save`, data)
       .then(this._successHandler, this._errorHandler);
   },
   feedback(context, data) {

--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -257,10 +257,10 @@ export default {
       const userUtcOffset = moment.tz.zone(this.selectedTz).parse(Date.now());
       // offsets returned by zone.utcOffset() are returned in minutes and inverted for POSIX compatibility
       const offset = (userUtcOffset - estUtcOffset) / 60;
-      CalendarService.updateTimezone(this, this.selectedTz);
-      CalendarService.updateAvailability(
+      CalendarService.updateSchedule(
         this,
-        this.convertAvailability(this.availability, offset)
+        this.convertAvailability(this.availability, offset),
+        this.selectedTz
       ).then(response => {
         if (response.status == 200) {
           this.saveState = saveStates.SAVED;


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/server/issues/214
- Server repo PR: https://github.com/UPchieve/server/pull/218

Description
-----------
- The client is updated so that it sends the availability and timezone into the single endpoint `/api/calendar/save`, rather than sending two separate HTTP requests for the single user action of clicking "Save".

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
