### PR TITLE
Add student partner signup flow that requires high school

### DIFF
--- a/src/views/SignupView/StudentForm.vue
+++ b/src/views/SignupView/StudentForm.vue
@@ -355,7 +355,7 @@ export default {
       this.invalidInputs = [];
 
       if (!this.eligibility.highSchool.upchieveId) {
-        this.errors.push("You must select a high school.");
+        this.errors.push("You must select your high school.");
       }
       if (this.errors.length) {
         return;

--- a/src/views/StudentPartnerSignupView.vue
+++ b/src/views/StudentPartnerSignupView.vue
@@ -27,9 +27,14 @@
             >
             <span v-else>Welcome to UPchieve!</span>
           </div>
-          <div v-if="studentPartner.name" class="step-header__subtitle">
-            Not with {{ studentPartner.name }}?
-            <router-link to="/signup">Click here</router-link>
+          <div class="step-header__subtitle">
+            <span v-if="studentPartner.name"
+              >Not with {{ studentPartner.name }}?
+              <router-link to="/signup">Click here</router-link></span
+            >
+            <span v-else
+              >We're a free online tutoring platform for HS students</span
+            >
           </div>
         </div>
 

--- a/src/views/StudentPartnerSignupView.vue
+++ b/src/views/StudentPartnerSignupView.vue
@@ -22,9 +22,12 @@
 
         <div class="step-header">
           <div class="step-header__title">
-            Welcome {{ studentPartner.name }} Student!
+            <span v-if="studentPartner.name"
+              >Welcome {{ studentPartner.name }} Student!</span
+            >
+            <span v-else>Welcome to UPchieve!</span>
           </div>
-          <div class="step-header__subtitle">
+          <div v-if="studentPartner.name" class="step-header__subtitle">
             Not with {{ studentPartner.name }}?
             <router-link to="/signup">Click here</router-link>
           </div>

--- a/src/views/StudentPartnerSignupView.vue
+++ b/src/views/StudentPartnerSignupView.vue
@@ -149,7 +149,7 @@
           />
         </div>
 
-        <div v-if="studentPartner.highSchoolSignup" class="uc-form-checkbox">
+        <div v-if="showHighSchoolCheckbox" class="uc-form-checkbox">
           <input
             id="highSchoolCheckbox"
             v-model="isHighSchoolStudent"
@@ -247,7 +247,8 @@ export default {
     return {
       studentPartner: {
         name: "",
-        highSchoolSignup: false
+        highSchoolSignup: false,
+        highSchoolSignupRequired: false
       },
       formStep: "step-1",
       isHighSchoolStudent: false,
@@ -266,8 +267,25 @@ export default {
     };
   },
   computed: {
-    showHighSchoolSelector() {
+    showHighSchoolCheckbox() {
+      // Don't show if high school input is disabled
       if (!this.studentPartner.highSchoolSignup) return false;
+
+      // Don't show if high school input is required
+      if (this.studentPartner.highSchoolSignupRequired) return false;
+
+      // Only show if high school input is enabled but not required, i.e. optional
+      return true;
+    },
+
+    showHighSchoolSelector() {
+      // No high school input
+      if (!this.studentPartner.highSchoolSignup) return false;
+
+      // Require high school input
+      if (this.studentPartner.highSchoolSignupRequired) return true;
+
+      // Optional high school input, so show if the checkbox is selected
       return this.isHighSchoolStudent;
     }
   },
@@ -360,6 +378,13 @@ export default {
       }
       if (!this.formData.lastName) {
         this.invalidInputs.push("lastName");
+      }
+      if (
+        this.studentPartner.highSchoolSignupRequired &&
+        !this.formData.highSchoolUpchieveId
+      ) {
+        this.errors.push("You must select your high school.");
+        this.invalidInputs.push("inputHighschool");
       }
       if (!this.formData.terms) {
         this.errors.push("You must read and accept the user agreement.");


### PR DESCRIPTION
Links
-----
- Server repo PR: https://github.com/UPchieve/server/pull/253

Description
-----------
- Handle new option (`highSchoolSignupRequired`) from student partner manifest that dictates whether high school signup is required
- Previously, there was only support for optional high school input using the `highSchoolSignup` manifest option 

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
