### PR TITLE
Loading ellipsis

### DIFF
--- a/src/views/SessionView/SessionHeader.vue
+++ b/src/views/SessionView/SessionHeader.vue
@@ -24,7 +24,7 @@
             </template>
           </template>
           <template v-else>
-            Loading...
+            Loading<span class="loading-ellipsis"></span>
           </template>
         </div>
       </div>

--- a/src/views/SessionView/SessionHeader.vue
+++ b/src/views/SessionView/SessionHeader.vue
@@ -5,7 +5,7 @@
         <div :style="partnerAvatar" class="avatar" />
         <div class="info">
           <template v-if="isSessionWaitingForVolunteer">
-            <span>
+            <span class="loading-message">
               Contacting coaches<span class="loading-ellipsis"></span>
             </span>
           </template>
@@ -24,7 +24,9 @@
             </template>
           </template>
           <template v-else>
-            Loading<span class="loading-ellipsis"></span>
+            <span class="loading-message">
+              Loading<span class="loading-ellipsis"></span>
+            </span>
           </template>
         </div>
       </div>
@@ -326,28 +328,38 @@ h1 {
   align-items: center;
 }
 
+.loading-message {
+  display: inline-flex;
+  align-self: flex-end;
+}
+
 .loading-ellipsis {
+  display: inline-flex;
+
   &:after {
-    content: "";
-    animation: 2s ellip infinite;
+    content: "...";
+    display: inline-block;
+    width: 25px;
+    overflow: hidden;
+    animation: 1.2s ellip infinite;
   }
 }
 
 @keyframes ellip {
-  20% {
-    content: ".";
+  0% {
+    width: 0px;
   }
 
-  40% {
-    content: "..";
+  33% {
+    width: 5px;
   }
 
-  60% {
-    content: "...";
+  66% {
+    width: 10px;
   }
 
-  80% {
-    content: "...";
+  100% {
+    width: 25px;
   }
 }
 </style>


### PR DESCRIPTION
Description
-----------
- The loading ellipses for when a student starts a session were not animating on mobile devices. The only reference I found related to issues with animating the `content` property is mentioned [here](https://css-tricks.com/animating-the-content-property/#article-header-id-2).  I opted for a no-js solution and instead of animating the `content` property we animate the `width` property and hide the ellipsis to make it look as if it's loading



Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
