### PR TITLE
align buttons to the right side of modals

### DIFF
--- a/src/views/DashboardView/VolunteerDashboard/OnboardingModal.vue
+++ b/src/views/DashboardView/VolunteerDashboard/OnboardingModal.vue
@@ -61,7 +61,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .OnboardingModal {
   @include flex-container(column);
   @include child-spacing(top, 24px);
@@ -99,9 +99,5 @@ export default {
 .OnboardingModal-steps-container {
   display: flex;
   justify-content: space-around;
-}
-
-.ModalTemplate-buttons {
-  justify-content: center !important;
 }
 </style>


### PR DESCRIPTION
Description
-----------
- Removed global styling that placed modal buttons to the center of the modal

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
