### PR TITLE
show test accounts to admins only

### DIFF
--- a/src/views/DashboardView/VolunteerDashboard/ListSessions.vue
+++ b/src/views/DashboardView/VolunteerDashboard/ListSessions.vue
@@ -72,6 +72,11 @@ export default {
         const currentSession = socketSessions[i];
         const { subTopic } = currentSession;
 
+        // Show test accounts to admins only
+        if (!this.user.isAdmin && currentSession.student.isTestUser) {
+          continue;
+        }
+
         if (
           Object.keys(allSubtopics()).some(
             s => s === subTopic && this.user.certifications[s].passed

--- a/src/views/DashboardView/VolunteerDashboard/ListSessions.vue
+++ b/src/views/DashboardView/VolunteerDashboard/ListSessions.vue
@@ -72,8 +72,11 @@ export default {
         const currentSession = socketSessions[i];
         const { subTopic } = currentSession;
 
-        // Show test accounts to admins only
-        if (!this.user.isAdmin && currentSession.student.isTestUser) {
+        // Show test accounts to admin and test volunteer accounts
+        if (
+          (!this.user.isAdmin || !this.user.isTestUser) &&
+          currentSession.student.isTestUser
+        ) {
           continue;
         }
 


### PR DESCRIPTION
Links
-----------
- Server repo PR: https://github.com/UPchieve/server/pull/262

Description
-----------
- Test student accounts can only be viewed by admin volunteer accounts

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
