### PR TITLE
Allow document-changed info to be null

### DIFF
--- a/src/views/SessionView/Whiteboard.vue
+++ b/src/views/SessionView/Whiteboard.vue
@@ -169,7 +169,7 @@ export default {
     this.useBrushTool();
 
     this.zwibblerCtx.on("document-changed", info => {
-      const isRemoteChange = info.remote;
+      const isRemoteChange = info && info.remote;
       const isWhiteboardHidden = this.mobileMode && !this.isVisible;
       const shouldResizeView = isRemoteChange && isWhiteboardHidden;
 


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/360

Description
-----------
- In the session-test file, info sometimes comes into this function as null.

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
