### PR TITLE
Query params on signup route for user type

### DIFF
--- a/src/views/SignupView/index.vue
+++ b/src/views/SignupView/index.vue
@@ -49,9 +49,9 @@ export default {
 
   created() {
     this.$store.dispatch("app/hideNavigation");
-    if (this.isMobileApp) {
-      this.selectStudent();
-    }
+
+    if (this.isMobileApp || this.$route.query.student) this.selectStudent();
+    else if (this.$route.query.volunteer) this.selectVolunteer();
   },
   computed: {
     ...mapState({


### PR DESCRIPTION
Links
-----
- Issue: https://upchieve.monday.com/boards/438837796/pulses/549531540

Description
-----------
- Add `?volunteer=true` or `?student=true` to skip choosing user type (or `=1`, `=yes`, any string)

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
