### PR TITLE
Disable only cards for starting tutoring sessions

### DIFF
--- a/src/views/DashboardView/StudentDashboard/SubjectSelection/SubjectCard.vue
+++ b/src/views/DashboardView/StudentDashboard/SubjectSelection/SubjectCard.vue
@@ -108,7 +108,7 @@ export default {
       isSessionAlive: "user/isSessionAlive"
     }),
     disabled() {
-      return this.isSessionAlive || this.disableSubjectCard;
+      return this.disableSubjectCard;
     }
   },
   methods: {

--- a/src/views/DashboardView/StudentDashboard/SubjectSelection/index.vue
+++ b/src/views/DashboardView/StudentDashboard/SubjectSelection/index.vue
@@ -17,7 +17,7 @@
       :subtopicDisplayNames="card.subtopicDisplayNames"
       :button-text="card.buttonText"
       :routeTo="card.routeTo"
-      :disableSubjectCard="disableSubjectCard"
+      :disableSubjectCard="isCardDisabled(card)"
     />
   </div>
 </template>
@@ -61,7 +61,8 @@ export default {
           .reduce((result, [subtopicKey, displayName]) => {
             result[subtopicKey] = displayName;
             return result;
-          }, {})
+          }, {}),
+        isTutoringCard: true
       };
     });
 
@@ -163,6 +164,9 @@ export default {
       } else {
         this.hasWaitingPeriod = false;
       }
+    },
+    isCardDisabled(card) {
+      return card.isTutoringCard && this.disableSubjectCard;
     }
   }
 };

--- a/src/views/DashboardView/StudentDashboard/SubjectSelection/index.vue
+++ b/src/views/DashboardView/StudentDashboard/SubjectSelection/index.vue
@@ -166,7 +166,9 @@ export default {
       }
     },
     isCardDisabled(card) {
-      return card.isTutoringCard && (this.disableSubjectCard || this.isSessionAlive);
+      return (
+        card.isTutoringCard && (this.disableSubjectCard || this.isSessionAlive)
+      );
     }
   }
 };

--- a/src/views/DashboardView/StudentDashboard/SubjectSelection/index.vue
+++ b/src/views/DashboardView/StudentDashboard/SubjectSelection/index.vue
@@ -166,7 +166,6 @@ export default {
       }
     },
     isCardDisabled(card) {
-      console.log(this.isSessionAlive);
       return card.isTutoringCard && (this.disableSubjectCard || this.isSessionAlive);
     }
   }

--- a/src/views/DashboardView/StudentDashboard/SubjectSelection/index.vue
+++ b/src/views/DashboardView/StudentDashboard/SubjectSelection/index.vue
@@ -166,7 +166,8 @@ export default {
       }
     },
     isCardDisabled(card) {
-      return card.isTutoringCard && this.disableSubjectCard;
+      console.log(this.isSessionAlive);
+      return card.isTutoringCard && (this.disableSubjectCard || this.isSessionAlive);
     }
   }
 };


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/396

Description
-----------
- A new property, `isTutoringCard`, is created to distinguish cards that are for starting tutoring sessions from cards that are for other purposes (like giving feedback). Only tutoring cards will now be disabled.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
