### PR TITLE
don't prefer polling

### DIFF
--- a/src/views/DashboardView/VolunteerDashboard/ListSessions.vue
+++ b/src/views/DashboardView/VolunteerDashboard/ListSessions.vue
@@ -45,7 +45,6 @@ export default {
   mounted() {
     // reconnect socket if it isn't already
     if (!this.$socket.connected) {
-      this.$socket.io.opts.transports = ["polling"];
       this.$socket.connect();
     }
     this.$socket.emit("list", {

--- a/src/views/SessionView/index.vue
+++ b/src/views/SessionView/index.vue
@@ -143,7 +143,6 @@ export default {
 
     promise
       .then(sessionId => {
-        this.$socket.io.opts.transports = ["polling", "websocket"];
         this.$socket.connect();
         this.joinSession(sessionId);
       })


### PR DESCRIPTION
Description
-----------
- Don't prefer polling for waitlist
- the version of vue-socket.io we have requires a 1.x version of socket.io-client, which is apparently mostly compatible with the 2.x server-side socket.io we have, besides
> it only (partly) breaks polling transport, so you can mix 1.x and 2.0 versions with websocket transport (which is the protocol used in the vast majority of cases)
  - https://github.com/socketio/socket.io/issues/3007#issuecomment-336825918
- The versioning issues are addressed in these PRs
  - https://github.com/UPchieve/web/pull/413
  - https://github.com/UPchieve/server/pull/351



Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
