### PR TITLE
set default transport to websocket

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,8 @@ Vue.config.productionTip = false;
 
 // Set up SocketIO
 const socket = Socket(process.env.VUE_APP_SOCKET_ADDRESS, {
-  autoConnect: false
+  autoConnect: false,
+  transports: ["websocket"]
 });
 Vue.use(VueSocketIO, socket);
 


### PR DESCRIPTION
Description
-----------
- Skip the default upgrade from long-polling that Socket.io tries to establish and instead default the transport to `websocket`

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
