### PR TITLE
use corresponding server branch

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -20,12 +20,33 @@ jobs:
     # Create directories to put in web and server
     - run: mkdir server
     - run: mkdir web
-    # Checks-out tthe server repository under $GITHUB_WORKSPACE/server
-    - uses: actions/checkout@v2
+    # Check whether there is a branch with the same name in server
+    - name: Check for branch of same name in server repo
+      run: |
+        if curl --head --silent --fail "https://github.com/UPchieve/server/tree/${{ github.head_ref }}" 2> /dev/null;
+         then
+          echo "found companion branch"
+          echo "::set-env name=HAS_SAME_SERVER_BRANCH::1"
+         else
+          echo "did not find companion branch"
+          echo "::set-env name=HAS_SAME_SERVER_BRANCH::0"
+        fi
+    # If no matching branch is found in server, checkout master to $GITHUB_WORKSPACE/server
+    - name: Checkout a master branch from server repo (if there is no matching branch in server)
+      if: env.HAS_SAME_SERVER_BRANCH == 0
+      uses: actions/checkout@v2
       with:
         repository: 'upchieve/server'
         path: 'server'
-    # Checks-out this web repository under $GITHUB_WORKSPACE/web
+    # If a matching branch is found in server, checkout that branch to $GITHUB_WORKSPACE/server
+    - name: Checkout a matching feature branch from server repo (if it exists)
+      if: env.HAS_SAME_SERVER_BRANCH == 1
+      uses: actions/checkout@v2
+      with:
+        repository: 'upchieve/server'
+        path: 'server'
+        ref: ${{ github.head_ref }}
+    # Checks-out this web repository to $GITHUB_WORKSPACE/web
     - uses: actions/checkout@v2
       with:
         path: 'web'


### PR DESCRIPTION
Links
------------
- You can test this with my [proof of concept](https://github.com/UPchieve/web/pull/423) without using many workflow minutes nor waiting too long for your test.


Description
-----------
- This change addresses the issue of submitting changes to both the server repo and the web repo, which must both be merged to pass Cypress integration tests. It institutes the following conditional workflow:
1. IIF A branch exists in [UPchieve/server](https://github.com/UPchieve/server) with the same name as the web branch you are merging, use that branch instead of master to run the Cypress CI tests.
1. Else, use the master branch to run the Cypress CI tests.

Developer self-review checklist
-------------------------------
- [X] Potentially confusing code has been explained with comments
- [X] No warnings or errors have been introduced; all known error cases have been handled
- [X] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [X] All edge cases have been addressed
