### PR TITLE
Redirect to feedback if session object becomes empty

### DIFF
--- a/src/views/SessionView/SessionHeader.vue
+++ b/src/views/SessionView/SessionHeader.vue
@@ -161,25 +161,6 @@ export default {
       }
 
       SessionService.endSession(this, sessionId)
-        .then(() => {
-          this.$socket.disconnect();
-          this.$store.dispatch("user/sessionDisconnected");
-          const url = volunteerId
-            ? "/feedback/" +
-              sessionId +
-              "/" +
-              topic +
-              "/" +
-              subTopic +
-              "/" +
-              (this.user.isVolunteer ? "volunteer" : "student") +
-              "/" +
-              studentId +
-              "/" +
-              volunteerId
-            : "/";
-          router.push(url);
-        })
         .catch(this.alertCouldNotEnd);
     },
     reportSession() {

--- a/src/views/SessionView/SessionHeader.vue
+++ b/src/views/SessionView/SessionHeader.vue
@@ -66,7 +66,6 @@
 import { mapState, mapGetters } from "vuex";
 
 import SessionService from "@/services/SessionService";
-import router from "@/router";
 import StudentAvatarUrl from "@/assets/defaultavatar3.png";
 import VolunteerAvatarUrl from "@/assets/defaultavatar4.png";
 import LoadingMessage from "@/components/LoadingMessage";
@@ -138,30 +137,9 @@ export default {
       }
       this.isSessionEnding = true;
 
-      let studentId = "";
-      let volunteerId = null;
-      let subTopic = null;
-      let topic = null;
       let sessionId = this.session._id;
 
-      if (this.session.student) {
-        studentId = this.session.student._id;
-      }
-
-      if (this.session.volunteer) {
-        volunteerId = this.session.volunteer._id;
-      }
-
-      if (this.session.type) {
-        topic = this.session.type;
-      }
-
-      if (this.session.subTopic) {
-        subTopic = this.session.subTopic;
-      }
-
-      SessionService.endSession(this, sessionId)
-        .catch(this.alertCouldNotEnd);
+      SessionService.endSession(this, sessionId).catch(this.alertCouldNotEnd);
     },
     reportSession() {
       this.$store.dispatch("app/modal/show", {

--- a/src/views/SessionView/index.vue
+++ b/src/views/SessionView/index.vue
@@ -278,22 +278,26 @@ export default {
         this.$socket.disconnect();
         this.$store.dispatch("user/sessionDisconnected");
 
-        // redirect user to feedback form
-        const url = volunteerId
-          ? "/feedback/" +
-            oldValue._id +
-            "/" +
-            oldValue.type +
-            "/" +
-            oldValue.subTopic +
-            "/" +
-            (this.user.isVolunteer ? "volunteer" : "student") +
-            "/" +
-            (oldValue.student ? oldValue.student._id : null) +
-            "/" +
-            (oldValue.volunteer ? oldValue.volunteer._id : null)
-          : "/";
-        router.push(url);
+        if (oldValue.volunteer) {
+          // if session had a volunteer, redirect user to feedback form
+          const url = oldValue.volunteer._id
+            ? "/feedback/" +
+              oldValue._id +
+              "/" +
+              oldValue.type +
+              "/" +
+              oldValue.subTopic +
+              "/" +
+              (this.user.isVolunteer ? "volunteer" : "student") +
+              "/" +
+              (oldValue.student ? oldValue.student._id : null) +
+              "/" +
+              (oldValue.volunteer ? oldValue.volunteer._id : null)
+            : "/";
+          this.$router.push(url);
+        } else {
+          this.$router.push("/");
+        }
       }
     },
     isSessionConnectionAlive(newValue, oldValue) {

--- a/src/views/SessionView/index.vue
+++ b/src/views/SessionView/index.vue
@@ -272,6 +272,30 @@ export default {
     }
   },
   watch: {
+    session(newValue, oldValue) {
+      if (!newValue.createdAt && oldValue.createdAt) {
+        // disconnect socket
+        this.$socket.disconnect();
+        this.$store.dispatch("user/sessionDisconnected");
+
+        // redirect user to feedback form
+        const url = volunteerId
+          ? "/feedback/" +
+            oldValue._id +
+            "/" +
+            oldValue.type +
+            "/" +
+            oldValue.subTopic +
+            "/" +
+            (this.user.isVolunteer ? "volunteer" : "student") +
+            "/" +
+            (oldValue.student ? oldValue.student._id : null) +
+            "/" +
+            (oldValue.volunteer ? oldValue.volunteer._id : null)
+          : "/";
+        router.push(url);
+      }
+    },
     isSessionConnectionAlive(newValue, oldValue) {
       if (newValue && !oldValue) {
         this.$store.dispatch("app/modal/hide");


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/442
- Server repo PR: https://github.com/UPchieve/server/pull/374

Description
-----------
- Redirect to feedback form whenever session object becomes empty in the course of a session, instead of looking at an `endedAt` property that might not exist
- The case of the session object becoming empty for a different reason (like an error retrieving the session data) needs to be addressed

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
