### PR TITLE
Signup routes

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -94,7 +94,7 @@ const routes = [
     }
   },
   {
-    path: "/sign-up/:type?/:step?",
+    path: "/sign-up/:userType?/:step?",
     name: "SignupView",
     component: SignupView,
     meta: { loggedOutOnly: true }

--- a/src/router.js
+++ b/src/router.js
@@ -89,6 +89,12 @@ const routes = [
   },
   {
     path: "/signup",
+    beforeEnter: (to, from, next) => {
+      next("/sign-up");
+    }
+  },
+  {
+    path: "/sign-up/:type?/:step?",
     name: "SignupView",
     component: SignupView,
     meta: { loggedOutOnly: true }

--- a/src/router.js
+++ b/src/router.js
@@ -115,7 +115,7 @@ const routes = [
     path: "/referral/:referredByCode",
     beforeEnter: (to, from, next) => {
       const referredByCode = to.params.referredByCode;
-      next(`/signup?referral=${referredByCode}`);
+      next(`/sign-up?referral=${referredByCode}`);
     }
   },
   {

--- a/src/router.js
+++ b/src/router.js
@@ -100,13 +100,6 @@ const routes = [
     meta: { loggedOutOnly: true }
   },
   {
-    path: "/referral/:referredByCode",
-    beforeEnter: (to, from, next) => {
-      const referredByCode = to.params.referredByCode;
-      next(`/signup?referral=${referredByCode}`);
-    }
-  },
-  {
     path: "/signup/student/:partnerId",
     name: "StudentPartnerSignupView",
     component: StudentPartnerSignupView,
@@ -117,6 +110,13 @@ const routes = [
     name: "VolunteerPartnerSignupView",
     component: VolunteerPartnerSignupView,
     meta: { loggedOutOnly: true }
+  },
+  {
+    path: "/referral/:referredByCode",
+    beforeEnter: (to, from, next) => {
+      const referredByCode = to.params.referredByCode;
+      next(`/signup?referral=${referredByCode}`);
+    }
   },
   {
     path: "/resetpassword",

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -3,7 +3,7 @@
     <form class="uc-form">
       <div class="uc-form-header">
         <div class="uc-form-header-link--active">Log In</div>
-        <router-link to="/signup" class="uc-form-header-link"
+        <router-link to="/sign-up" class="uc-form-header-link"
           >Sign Up</router-link
         >
       </div>

--- a/src/views/ResetPasswordView.vue
+++ b/src/views/ResetPasswordView.vue
@@ -15,7 +15,7 @@
             Log In
           </router-link>
           <span>/</span>
-          <router-link to="/signup" class="uc-form-header-link">
+          <router-link to="/sign-up" class="uc-form-header-link">
             Sign Up
           </router-link>
         </div>

--- a/src/views/SignupView/StudentForm.vue
+++ b/src/views/SignupView/StudentForm.vue
@@ -430,7 +430,7 @@ export default {
       NetworkService.checkStudentEligibility(this, {
         schoolUpchieveId: this.eligibility.highSchool.upchieveId,
         zipCode: this.eligibility.zipCode,
-        referredByCode: this.$route.query.referral
+        referredByCode: window.localStorage.getItem("upcReferredByCode")
       })
         .then(response => {
           const isEligible = response.body.isEligible;
@@ -572,9 +572,10 @@ export default {
         lastName: this.profile.lastName,
         highSchoolId: this.eligibility.highSchool.upchieveId,
         zipCode: this.eligibility.zipCode,
-        referredByCode: this.$route.query.referral
+        referredByCode: window.localStorage.getItem("upcReferredByCode")
       })
         .then(() => {
+          window.localStorage.removeItem("upcReferredByCode");
           this.$store.dispatch("user/firstDashboardVisit", true);
           this.$router.push("/dashboard");
         })

--- a/src/views/SignupView/StudentForm.vue
+++ b/src/views/SignupView/StudentForm.vue
@@ -372,6 +372,7 @@ export default {
   methods: {
     firstPage() {
       this.step = "step-1";
+      this.$router.push("/sign-up/student/eligibility");
     },
 
     signupCodeYes() {
@@ -434,8 +435,10 @@ export default {
 
           if (isEligible) {
             this.step = "step-2";
+            this.$router.push("/sign-up/student/account");
           } else {
             this.step = "step-1-waitlist";
+            this.$router.push("/sign-up/student/waitlist");
           }
         })
         .catch(err => {
@@ -474,6 +477,7 @@ export default {
       })
         .then(() => {
           this.step = "step-3";
+          this.$router.push("/sign-up/student/name");
         })
         .catch(err => {
           this.msg = err.message;
@@ -507,6 +511,7 @@ export default {
       })
         .then(() => {
           this.step = "step-1-waitlist-success";
+          this.$router.push("/sign-up/student/waitlist-success");
         })
         .catch(err => {
           this.msg = err.message;

--- a/src/views/SignupView/StudentForm.vue
+++ b/src/views/SignupView/StudentForm.vue
@@ -479,7 +479,7 @@ export default {
       })
         .then(() => {
           this.step = "step-3";
-          this.$router.push("/sign-up/student/name");
+          this.$router.push("/sign-up/student/about");
         })
         .catch(err => {
           this.msg = err.message;

--- a/src/views/SignupView/StudentForm.vue
+++ b/src/views/SignupView/StudentForm.vue
@@ -360,7 +360,9 @@ export default {
     };
   },
   mounted() {
-    if (!this.isMobileApp) {
+    if (this.isMobileApp) {
+      this.$router.push("/sign-up/student/partner-code");
+    } else {
       this.firstPage();
     }
   },

--- a/src/views/SignupView/VolunteerForm/CodeForm.vue
+++ b/src/views/SignupView/VolunteerForm/CodeForm.vue
@@ -41,6 +41,8 @@ export default {
         isValid => {
           if (!isValid) {
             this.msg = "Sorry, that code is invalid";
+          } else {
+            this.$router.push("/sign-up/volunteer/account");
           }
         }
       );

--- a/src/views/SignupView/VolunteerForm/VolunteerSignupForm.vue
+++ b/src/views/SignupView/VolunteerForm/VolunteerSignupForm.vue
@@ -264,6 +264,7 @@ export default {
       })
         .then(() => {
           this.step = "step-2";
+          this.$router.push("/sign-up/volunteer/about");
         })
         .catch(err => {
           this.msg = err.message;

--- a/src/views/SignupView/VolunteerForm/index.vue
+++ b/src/views/SignupView/VolunteerForm/index.vue
@@ -16,6 +16,11 @@ export default {
   },
   data() {
     return RegistrationService.data;
+  },
+  created() {
+    if (this.isValidRegistrationCode)
+      this.$router.push("/sign-up/volunteer/account");
+    else this.$router.push("/sign-up/volunteer/registration-code");
   }
 };
 </script>

--- a/src/views/SignupView/index.vue
+++ b/src/views/SignupView/index.vue
@@ -50,6 +50,12 @@ export default {
   created() {
     this.$store.dispatch("app/hideNavigation");
 
+    if (this.$route.query.referral)
+      window.localStorage.setItem(
+        "upcReferredByCode",
+        this.$route.query.referral
+      );
+
     if (this.$route.params)
       if (this.isMobileApp || this.$route.params.userType === "student")
         this.userSelection = "student";

--- a/src/views/SignupView/index.vue
+++ b/src/views/SignupView/index.vue
@@ -51,9 +51,9 @@ export default {
     this.$store.dispatch("app/hideNavigation");
 
     if (this.$route.params)
-      if (this.isMobileApp || this.$route.params.type === "student")
+      if (this.isMobileApp || this.$route.params.userType === "student")
         this.userSelection = "student";
-      else if (this.$route.params.type === "volunteer")
+      else if (this.$route.params.userType === "volunteer")
         this.userSelection = "volunteer";
   },
   computed: {

--- a/src/views/SignupView/index.vue
+++ b/src/views/SignupView/index.vue
@@ -50,8 +50,11 @@ export default {
   created() {
     this.$store.dispatch("app/hideNavigation");
 
-    if (this.isMobileApp || this.$route.query.student) this.selectStudent();
-    else if (this.$route.query.volunteer) this.selectVolunteer();
+    if (this.$route.params)
+      if (this.isMobileApp || this.$route.params.type === "student")
+        this.userSelection = "student";
+      else if (this.$route.params.type === "volunteer")
+        this.userSelection = "volunteer";
   },
   computed: {
     ...mapState({
@@ -65,9 +68,11 @@ export default {
   },
   methods: {
     selectVolunteer() {
+      this.$router.push("/sign-up/volunteer");
       this.userSelection = "volunteer";
     },
     selectStudent() {
+      this.$router.push("/sign-up/student");
       this.userSelection = "student";
     }
   }

--- a/src/views/StudentPartnerSignupView.vue
+++ b/src/views/StudentPartnerSignupView.vue
@@ -30,7 +30,7 @@
           <div class="step-header__subtitle">
             <span v-if="studentPartner.name"
               >Not with {{ studentPartner.name }}?
-              <router-link to="/signup">Click here</router-link></span
+              <router-link to="/sign-up">Click here</router-link></span
             >
             <span v-else
               >We're a free online tutoring platform for HS students</span
@@ -238,7 +238,7 @@ export default {
     NetworkService.getStudentPartner(partnerId)
       .then(data => {
         const studentPartner = data.body.studentPartner;
-        if (!studentPartner) return next("/signup");
+        if (!studentPartner) return next("/sign-up");
         return next(_this => _this.setStudentPartner(studentPartner));
       })
       .catch(err => {
@@ -247,7 +247,7 @@ export default {
           // to be correct regardless of user input
           Sentry.captureException(err);
         }
-        return next("/signup");
+        return next("/sign-up");
       });
   },
   created() {

--- a/src/views/VolunteerPartnerSignupView.vue
+++ b/src/views/VolunteerPartnerSignupView.vue
@@ -228,7 +228,7 @@ export default {
     NetworkService.getVolunteerPartner(partnerId)
       .then(data => {
         const volunteerPartner = data.body.volunteerPartner;
-        if (!volunteerPartner) return next("/signup");
+        if (!volunteerPartner) return next("/sign-up");
         return next(_this => _this.setVolunteerPartner(volunteerPartner));
       })
       .catch(err => {
@@ -237,7 +237,7 @@ export default {
           // to be correct regardless of user input
           Sentry.captureException(err);
         }
-        return next("/signup");
+        return next("/sign-up");
       });
   },
   created() {

--- a/tests/e2e/specs/signup-tests.js
+++ b/tests/e2e/specs/signup-tests.js
@@ -28,9 +28,9 @@ describe("Student and volunteer signup", () => {
     it("Should successfully create a new student account", function() {
       cy.server();
 
-      cy.visit("/signup");
+      cy.visit("/sign-up");
 
-      cy.location("pathname").should("eq", "/signup");
+      cy.location("pathname").should("eq", "/sign-up");
 
       cy.get("button")
         .contains("Student")
@@ -76,9 +76,9 @@ describe("Student and volunteer signup", () => {
     });
 
     it("Should add student to waitlist", function() {
-      cy.visit("/signup");
+      cy.visit("/sign-up");
 
-      cy.location("pathname").should("eq", "/signup");
+      cy.location("pathname").should("eq", "/sign-up");
 
       cy.get("button")
         .contains("Student")
@@ -124,9 +124,9 @@ describe("Student and volunteer signup", () => {
       cy.server();
       cy.route("POST", "/auth/register/volunteer").as("registerVolunteer");
 
-      cy.visit("/signup");
+      cy.visit("/sign-up");
 
-      cy.location("pathname").should("eq", "/signup");
+      cy.location("pathname").should("eq", "/sign-up");
 
       cy.get("button")
         .contains("Volunteer")
@@ -218,9 +218,9 @@ describe("Student and volunteer signup", () => {
     });
 
     it("Should not accept invalid code", function() {
-      cy.visit("/signup");
+      cy.visit("/sign-up");
 
-      cy.location("pathname").should("eq", "/signup");
+      cy.location("pathname").should("eq", "/sign-up");
 
       cy.get("button")
         .contains("Volunteer")


### PR DESCRIPTION
Description
-----------
- Indicate signup step in URL using optional params: `/sign-up/:userType?/:step?`
- To avoid overlap between the partner signup routes and open signup routes, route open signup through `/sign-up` instead of `/signup`
    - (because `/signup/student/partnerName` can't be distinguished from `/signup/student/stepName`)
    - Other options were:
        - move partner signup to `/signup/partner/student/partnerName` (would have to change partner links though)
        - for open signup, use the pattern `/signup/open/student/stepName` (moving to `sign-up` seemed simpler though)
- Redirect from `/signup` to `/sign-up`

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
