### PR TITLE
Add e2e tests for user profile

### DIFF
--- a/tests/e2e/specs/profile-tests.js
+++ b/tests/e2e/specs/profile-tests.js
@@ -1,0 +1,53 @@
+describe("Profile modification", () => {
+  beforeEach(function() {
+    cy.fixture("users/volunteer1").then(volunteer => {
+      cy.login(volunteer);
+    });
+    cy.visit("/profile");
+  });
+
+  it("Should be able to edit phone number", function() {
+    cy.get("button")
+      .contains("Edit")
+      .click();
+
+    // Force the element to be cleared because Cypress incorrectly believes it's
+    // being covered by another element.
+    cy.get("#phone")
+      .find("#VuePhoneNumberInput_phone_number")
+      .clear({ force: true })
+      .type("2125550212")
+      .should("have.value", "(212) 555-0212");
+
+    cy.get("button")
+      .contains("Save")
+      .click();
+
+    cy.reload();
+
+    cy.get("#phone").should("contain", "+1 212-555-0212");
+  });
+
+  it("Should not be able to save an invalid phone number", function() {
+    cy.get("button")
+      .contains("Edit")
+      .click();
+
+    // Force the element to be cleared because Cypress incorrectly believes it's
+    // being covered by another element.
+    cy.get("#phone")
+      .find("#VuePhoneNumberInput_phone_number")
+      .clear({ force: true })
+      .type("5550212")
+      .should("have.value", "(555) 021-2");
+
+    cy.get("button")
+      .contains("Save")
+      .click();
+
+    cy.get(".errors-list").should(
+      "contain",
+      "Please enter a valid phone number."
+    );
+  });
+});


### PR DESCRIPTION
Links
-----
- Issue: https://github.com/UPchieve/web/issues/438

Description
-----------
I'm adding e2e tests for user profiles. These tests verify that:
* Users can update their phone number
* Users can't enter an invalid phone number

I ran into a documented issue with Cypress where it isn't properly scrolling an element into view. This issue is being tracked at: https://github.com/cypress-io/cypress/issues/871. I forced a few actions to work around this, but there are some additional workaround options suggested on the issue page. 

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
