### PR TITLE
use $refs instead of querySelector

### DIFF
--- a/src/views/SessionView/Whiteboard.vue
+++ b/src/views/SessionView/Whiteboard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="zwib-wrapper" :class="toolClass">
-    <div id="zwib-div"></div>
+    <div id="zwib-div" ref="zwibDiv"></div>
     <div id="toolbar" class="toolbar">
       <p v-if="error" class="whiteboard-error">{{ error }}</p>
       <div
@@ -314,7 +314,7 @@ export default {
     });
 
     if (!this.mobileMode) {
-      const zwibblerContainer = document.querySelector("#zwib-div");
+      const zwibblerContainer = this.$refs.zwibDiv;
       zwibblerContainer.addEventListener("wheel", this.trackpadListener, false);
       // Safari doesn't register wheel events for the trackpad pinch
       zwibblerContainer.addEventListener(
@@ -532,9 +532,9 @@ export default {
       this.previousScale = scale;
     }
   },
-  destroyed() {
+  beforeDestroy() {
     if (!this.mobileMode) {
-      const zwibblerContainer = document.querySelector("#zwib-div");
+      const zwibblerContainer = this.$refs.zwibDiv;
       zwibblerContainer.removeEventListener(
         "wheel",
         this.trackpadListener,


### PR DESCRIPTION
Description
-----------
- Fixes "Cannot read property 'removeEventListener' of null" issue - `document.querySelector` returned null in the `destroyed` and `beforeDestroy` lifecycle hook - replaced with refs

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
