### PR TITLE
remove overflow that cuts off drop down

### DIFF
--- a/src/views/Admin/AdminReports.vue
+++ b/src/views/Admin/AdminReports.vue
@@ -267,7 +267,6 @@ export default {
   margin: 10px;
   padding: 10px;
   border-radius: 8px;
-  overflow: hidden;
 
   @include breakpoint-above("medium") {
     margin: 40px;


### PR DESCRIPTION
Links
-----
- Server repo PR: https://github.com/UPchieve/server/pull/444

Description
-----------
- Remove overflow hidden from the container that cut off the partner site dropdown

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
