### PR TITLE
add isVolunteer getter

### DIFF
--- a/src/views/SessionView/index.vue
+++ b/src/views/SessionView/index.vue
@@ -117,7 +117,8 @@ export default {
     }),
     ...mapGetters({
       mobileMode: "app/mobileMode",
-      isAuthenticated: "user/isAuthenticated"
+      isAuthenticated: "user/isAuthenticated",
+      isVolunteer: "user/isVolunteer"
     }),
 
     auxiliaryType() {


### PR DESCRIPTION
Description
-----------
- Fixed "Cannot read property 'click' of null" on ` document.querySelector(".upload-photo").click();` by adding missing `isVolunteer` getter

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
