### PR TITLE
Fix session modal close

### DIFF
--- a/src/components/App/AppModal/ModalTemplate.vue
+++ b/src/components/App/AppModal/ModalTemplate.vue
@@ -5,7 +5,11 @@
     @click="closeModal"
   >
     <div v-if="mobileMode" class="ModalTemplate-header">
-      <div class="ModalTemplate-header-close-button" @click="handleCancel">
+      <div
+        class="ModalTemplate-header-close-button"
+        @click="handleCancel"
+        v-if="!isSessionFulfilledModal"
+      >
         <arrow-icon class="icon" />
         <p>{{ backText }}</p>
       </div>
@@ -49,7 +53,8 @@ export default {
     alertModal: Boolean,
     important: Boolean,
     showTemplateButtons: { type: Boolean, default: true },
-    showAccept: { type: Boolean, default: true }
+    showAccept: { type: Boolean, default: true },
+    modalComponentName: String
   },
   mounted() {
     const body = document.querySelector("body");
@@ -60,7 +65,10 @@ export default {
     body.classList.remove("disable-scroll");
   },
   computed: {
-    ...mapGetters({ mobileMode: "app/mobileMode" })
+    ...mapGetters({ mobileMode: "app/mobileMode" }),
+    isSessionFulfilledModal() {
+      return this.modalComponentName === "SessionFulfilledModal";
+    }
   },
   methods: {
     handleCancel() {
@@ -68,6 +76,8 @@ export default {
       this.$store.dispatch("app/modal/hide");
     },
     closeModal(event) {
+      // users must interact with the modal button to close session related modals
+      if (this.isSessionFulfilledModal) return;
       const { target } = event;
       if (target.classList.contains("ModalTemplate")) this.handleCancel();
     }

--- a/src/components/App/AppModal/index.vue
+++ b/src/components/App/AppModal/index.vue
@@ -9,6 +9,7 @@
     :important="modalData.important"
     :showTemplateButtons="modalData.showTemplateButtons"
     :show-accept="modalData.showAccept"
+    :modalComponentName="modalComponent.name"
   >
     <component
       v-if="modalComponent"

--- a/src/components/App/AppModal/index.vue
+++ b/src/components/App/AppModal/index.vue
@@ -9,7 +9,7 @@
     :important="modalData.important"
     :showTemplateButtons="modalData.showTemplateButtons"
     :show-accept="modalData.showAccept"
-    :modalComponentName="modalComponent.name"
+    :modalComponentName="modalComponent && modalComponent.name"
   >
     <component
       v-if="modalComponent"

--- a/src/views/SessionView/SessionFulfilledModal.vue
+++ b/src/views/SessionView/SessionFulfilledModal.vue
@@ -13,6 +13,7 @@ import { mapGetters } from "vuex";
 import LargeButton from "@/components/LargeButton";
 
 export default {
+  name: "SessionFulfilledModal",
   components: { LargeButton },
   props: {
     modalData: { type: Object, required: true }


### PR DESCRIPTION
Description
-----------
- If the modal component is `SessionFulfilledModal` don't allow users to close the modal by clicking outside of it
- Removed the `back` button for `SessionFulfilledModal`. Noticed that in mobile mode a user can press `back` on the modal and still land on the whiteboard when receiving the "session fulfilled message"

Developer self-review checklist
-------------------------------
- [ ] Potentially confusing code has been explained with comments
- [ ] No warnings or errors have been introduced; all known error cases have been handled
- [ ] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [ ] All edge cases have been addressed
