### PR TITLE
Fix topic display name

### DIFF
--- a/src/components/Admin/SessionListItem.vue
+++ b/src/components/Admin/SessionListItem.vue
@@ -54,6 +54,8 @@ export default {
 
     subTopicDisplayName() {
       const { type, subTopic } = this.session;
+      if (subTopic === "algebra") return "Algebra";
+      if (subTopic === "calculus") return "Calculus";
       return topics[type].subtopics[subTopic].displayName;
     },
 

--- a/src/views/Admin/VolunteerCoverage.vue
+++ b/src/views/Admin/VolunteerCoverage.vue
@@ -115,7 +115,7 @@ export default {
       lessThan: "",
       greaterThan: "",
       // dropdown menu options
-      selected: "algebra", // default
+      selected: "algebraOne", // default
       topics: allSubtopicNames(),
       // availability objects
       availabilityTable: {}
@@ -131,7 +131,9 @@ export default {
         the number of volunteers available at that day and hour block who are certified
         in the "certifiedSubject". */
     getAvailability(certifiedSubject) {
-      UserService.getVolunteersAvailability(this, certifiedSubject)
+      let cert = certifiedSubject;
+      if (certifiedSubject.match(/^algebra/i)) cert = "algebra";
+      UserService.getVolunteersAvailability(this, cert)
         .then(availability => {
           this.availabilityTable = availability;
           //flattening table makes the implementation of css grid cleaner


### PR DESCRIPTION
Description
-----------
- Temporary fix for old sessions that have `algebra` and `calculus` as their subtopic

Note: a better fix might be a migration of those old sessions to `algebraOne` and `calculusAB`, but don't know how many other scripts are dependant on the sessions showing those subtopics

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
