### PR TITLE
remove display name for old subtopics on sessions

### DIFF
--- a/src/components/Admin/SessionListItem.vue
+++ b/src/components/Admin/SessionListItem.vue
@@ -54,8 +54,6 @@ export default {
 
     subTopicDisplayName() {
       const { type, subTopic } = this.session;
-      if (subTopic === "algebra") return "Algebra";
-      if (subTopic === "calculus") return "Calculus";
       return topics[type].subtopics[subTopic].displayName;
     },
 


### PR DESCRIPTION
Description
-----------
- A migration has changed subtopics on Feedback and Session collections from `algebra` -> `algebraOne` and `calculus` -> `calculusAB` so no need for the display names for `algebra` and `calculus` anymore

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
