### PR TITLE
return empty object if school is undefined

### DIFF
--- a/src/views/SignupView/StudentForm.vue
+++ b/src/views/SignupView/StudentForm.vue
@@ -305,7 +305,8 @@ export default {
       eligibility: {
         noSchoolResults: false,
         highSchool: {},
-        zipCode: ""
+        zipCode: "",
+        email: ""
       },
       credentials: {
         email: "",
@@ -454,7 +455,7 @@ export default {
       return `${school.name} (${school.city}, ${school.state})`;
     },
     handleSelectHighSchool(school) {
-      this.eligibility.highSchool = school;
+      this.eligibility.highSchool = school || {};
     },
     submitAccountForm() {
       this.errors = [];


### PR DESCRIPTION
Description
-----------
- When no school is selected or when a school that isn't listed in the `autocomplete` component is submitted, it sets `this.eligibility.highSchool` to `undefined`. This fixes PR a TypeError that appears when trying to access `upchieveId` of `undefined`

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
