### PR TITLE
workaround for Zwibbler photo deletion wb crash

### DIFF
--- a/src/views/SessionView/Whiteboard.vue
+++ b/src/views/SessionView/Whiteboard.vue
@@ -598,8 +598,8 @@ export default {
 
       this.zwibblerCtx.on("nodes-removed", nodes => {
         /**
-         * If an imageNode is being removed disable
-         * the ability to undo a photo deletion
+         * If an imageNode is being removed clear the undo stack
+         * to disable the ability to undo a photo deletion
          *
          * @note: the whiteboard would crash when one user undos a photo
          * deletion that was deleted by the other user

--- a/src/views/SessionView/Whiteboard.vue
+++ b/src/views/SessionView/Whiteboard.vue
@@ -252,7 +252,8 @@ export default {
       hadConnectionIssue: false,
       showResetWhiteboardModal: false,
       shouldResetWhiteboard: false,
-      resetWhiteboardError: false
+      resetWhiteboardError: false,
+      selectedImageNodes: []
     };
   },
   computed: {
@@ -593,6 +594,34 @@ export default {
       this.zwibblerCtx.on("nodes-added", nodes => {
         if (this.isShapeSelected) this.shapeNodes.push(nodes[0]);
         if (this.selectedTool === "text") this.usePickTool();
+      });
+
+      this.zwibblerCtx.on("nodes-removed", nodes => {
+        /**
+         * If an imageNode is being removed disable
+         * the ability to undo a photo deletion
+         *
+         * @note: the whiteboard would crash when one user undos a photo
+         * deletion that was deleted by the other user
+         */
+        if (nodes.some(node => this.selectedImageNodes.includes(node))) {
+          this.selectedImageNodes = [];
+          this.zwibblerCtx.clearUndo();
+        }
+      });
+
+      this.zwibblerCtx.on("selected-nodes", () => {
+        const nodes = this.zwibblerCtx.getSelectedNodes();
+        // Keep a reference to the previously selected image
+        // nodes if there are no nodes currently selected
+        if (nodes.length === 0 && this.selectedImageNodes.length > 0) return;
+
+        const selectedImageNodes = [];
+        for (const node of nodes) {
+          const isImageNode = this.zwibblerCtx.getNodeProperty(node, "url");
+          if (isImageNode) selectedImageNodes.push(node);
+        }
+        this.selectedImageNodes = selectedImageNodes;
       });
 
       window.addEventListener(


### PR DESCRIPTION
Description
-----------
- When a student presses undo after a volunteer has deleted a photo that the student has uploaded, it would cause the whiteboard to crash throwing an error in Zwibbler. This PR works around that by clearing the undo stack after a photo has been deleted so that no user can undo the deletion


Steps to test:
1. Start a session and join in as a volunteer
2. Student - upload a photo
3. Volunteer - select and delete the photo
4. Should be unable to undo the photo deletion on both volunteer and student side

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
