### PR TITLE
Upgrade whiteboard

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,5 @@
 VUE_APP_SERVER_ROOT="https://app.upchieve.org"
 VUE_APP_SOCKET_ADDRESS="https://app.upchieve.org"
 VUE_APP_SEGMENT_KEY="cEOpUvWZ2BLM0mZVCKUnVG8jJS1pVsfq"
-VUE_APP_ZWIBBLER_URL="/static/js/zwibbler2_june2020.js"
+VUE_APP_ZWIBBLER_URL="/static/js/zwibbler2_sept2020.js"
 VUE_APP_WEBSOCKET_ROOT="wss://app.upchieve.org"

--- a/.env.staging
+++ b/.env.staging
@@ -2,5 +2,5 @@ NODE_ENV=production
 VUE_APP_SERVER_ROOT="https://staging.upchieve.org"
 VUE_APP_SOCKET_ADDRESS="https://staging.upchieve.org"
 VUE_APP_SEGMENT_KEY="mmbhVBzFfWUfzQuhoPK13ZBZ4EVJ3uXg"
-VUE_APP_ZWIBBLER_URL="/static/js/zwibbler2_june2020.js"
+VUE_APP_ZWIBBLER_URL="/static/js/zwibbler2_sept2020.js"
 VUE_APP_WEBSOCKET_ROOT="wss://staging.upchieve.org"

--- a/src/views/Admin/AdminSessionDetail.vue
+++ b/src/views/Admin/AdminSessionDetail.vue
@@ -15,7 +15,7 @@
       "
     >
       <h3 class="session-detail__section-title">Review Session</h3>
-      <p v-if="reviewError">
+      <p v-if="reviewError" class="error">
         There was an issue submitting your review for this session.
       </p>
 
@@ -146,6 +146,9 @@
       class="session-detail__section session-detail__section--whiteboard"
     >
       <h2 class="session-detail__section-title">Whiteboard</h2>
+      <p v-if="loadingWhiteboardError" class="error">
+        {{ loadingWhiteboardError }}
+      </p>
       <div id="zwibbler-container"></div>
     </div>
   </div>
@@ -178,7 +181,8 @@ export default {
       session: {},
       quillEditor: null,
       zwibblerCtx: null,
-      reviewError: false
+      reviewError: false,
+      loadingWhiteboardError: ""
     };
   },
 
@@ -234,7 +238,7 @@ export default {
     this.session = session;
 
     // Set quill document after the DOM has been updated to show session div
-    this.$nextTick(() => {
+    this.$nextTick(async () => {
       if (this.session.quillDoc) {
         const container = document.querySelector(".quill-container");
         this.quillEditor = new Quill(container);
@@ -252,7 +256,11 @@ export default {
           readOnly: true
         });
 
-        this.zwibblerCtx.joinSharedSession(this.session._id, false);
+        try {
+          await this.zwibblerCtx.joinSharedSession(this.session._id, false);
+        } catch (error) {
+          this.loadingWhiteboardError = "Failed to load the whiteboard.";
+        }
 
         this.zwibblerCtx.on("connected", () => {
           this.zwibblerCtx.usePanTool();
@@ -403,5 +411,10 @@ export default {
 
 .separator {
   margin: 2em 0;
+}
+
+.error {
+  color: $c-error-red;
+  margin: 1em 0;
 }
 </style>

--- a/src/views/SessionView/Whiteboard.vue
+++ b/src/views/SessionView/Whiteboard.vue
@@ -553,7 +553,7 @@ export default {
         this.zwibblerCtx.setConfig("readOnly", false);
 
         // @todo access the connection in a less sketchy way
-        const zwibblerWsConnection = this.zwibblerCtx.zc.Pb.Pb;
+        const zwibblerWsConnection = this.zwibblerCtx.fc.Rb.Rb;
         const zwibblerOnMessage = zwibblerWsConnection.onmessage;
         // Intercept Zwibbler's websocket message handler
         zwibblerWsConnection.onmessage = messageEvent => {

--- a/src/views/SessionView/Whiteboard.vue
+++ b/src/views/SessionView/Whiteboard.vue
@@ -252,8 +252,7 @@ export default {
       hadConnectionIssue: false,
       showResetWhiteboardModal: false,
       shouldResetWhiteboard: false,
-      resetWhiteboardError: false,
-      selectedImageNodes: []
+      resetWhiteboardError: false
     };
   },
   computed: {
@@ -594,34 +593,6 @@ export default {
       this.zwibblerCtx.on("nodes-added", nodes => {
         if (this.isShapeSelected) this.shapeNodes.push(nodes[0]);
         if (this.selectedTool === "text") this.usePickTool();
-      });
-
-      this.zwibblerCtx.on("nodes-removed", nodes => {
-        /**
-         * If an imageNode is being removed clear the undo stack
-         * to disable the ability to undo a photo deletion
-         *
-         * @note: the whiteboard would crash when one user undos a photo
-         * deletion that was deleted by the other user
-         */
-        if (nodes.some(node => this.selectedImageNodes.includes(node))) {
-          this.selectedImageNodes = [];
-          this.zwibblerCtx.clearUndo();
-        }
-      });
-
-      this.zwibblerCtx.on("selected-nodes", () => {
-        const nodes = this.zwibblerCtx.getSelectedNodes();
-        // Keep a reference to the previously selected image
-        // nodes if there are no nodes currently selected
-        if (nodes.length === 0 && this.selectedImageNodes.length > 0) return;
-
-        const selectedImageNodes = [];
-        for (const node of nodes) {
-          const isImageNode = this.zwibblerCtx.getNodeProperty(node, "url");
-          if (isImageNode) selectedImageNodes.push(node);
-        }
-        this.selectedImageNodes = selectedImageNodes;
       });
 
       window.addEventListener(


### PR DESCRIPTION
Description
-----------
- Upgraded whiteboard to the most recent Zwibbler release
- Added a "failed to load whiteboard" error message on the admin session page
- Removed clearing the undo stack when deleting a photo. The new Zwibbler update fixes the whiteboard crash that happens after undoing a photo deletion

### Steps to test:
**Whiteboard:**
1. Start a session as a student
2. Join in as a volunteer
3. Try all tools on the whiteboard
4. Upload a photo as a student
5. Delete photo as volunteer
6. Press undo as a student 
7. Whiteboard should still work properly
8. Repeat for mobile web

**Admin:**
1. Log into an admin volunteer account 
2. Click `Admin` on the sidebar
3. Click `Sessions`
4. Click on an older session that used the old whiteboard format
5. Should see an error message saying that the whiteboard was unable to load for older session formats

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
