### PR TITLE
ignores xhr poll error messages

### DIFF
--- a/src/components/App/index.vue
+++ b/src/components/App/index.vue
@@ -177,7 +177,7 @@ export default {
     error(error) {
       // these are handled internally and shouldn't be forwarded to Sentry
       if (error.message === "xhr poll error") {
-        return
+        return;
       }
       Sentry.captureException(error);
     },

--- a/src/components/App/index.vue
+++ b/src/components/App/index.vue
@@ -175,6 +175,7 @@ export default {
   },
   sockets: {
     error(error) {
+      // these are handled internally and shouldn't be forwarded to Sentry
       if (error.message === "xhr poll error") {
         return
       }

--- a/src/components/App/index.vue
+++ b/src/components/App/index.vue
@@ -177,14 +177,23 @@ export default {
     error(error) {
       // these are handled internally and shouldn't be forwarded to Sentry
       if (error.message === "xhr poll error") {
+        console.log("xhr poll error in error event")
         return;
       }
       Sentry.captureException(error);
     },
     connect_error(error) {
+      if (error.message === "xhr poll error") {
+        console.log("xhr poll error in connect_error event")
+        return;
+      }
       Sentry.captureException(error);
     },
     reconnect_error(error) {
+      if (error.message === "xhr poll error") {
+        console.log("xhr poll error in reconnect_error event")
+        return;
+      }
       Sentry.captureException(error);
     },
     "session-change"(sessionData) {

--- a/src/components/App/index.vue
+++ b/src/components/App/index.vue
@@ -175,25 +175,19 @@ export default {
   },
   sockets: {
     error(error) {
-      // these are handled internally and shouldn't be forwarded to Sentry
-      if (error.message === "xhr poll error") {
-        console.log("xhr poll error in error event")
-        return;
-      }
       Sentry.captureException(error);
     },
     connect_error(error) {
-      if (error.message === "xhr poll error") {
-        console.log("xhr poll error in connect_error event")
+      // these are handled internally and shouldn't be forwarded to Sentry
+      if (
+        error.message === "xhr poll error" || 
+        error.message === "websocket error"
+      ) {
         return;
       }
       Sentry.captureException(error);
     },
     reconnect_error(error) {
-      if (error.message === "xhr poll error") {
-        console.log("xhr poll error in reconnect_error event")
-        return;
-      }
       Sentry.captureException(error);
     },
     "session-change"(sessionData) {

--- a/src/components/App/index.vue
+++ b/src/components/App/index.vue
@@ -180,7 +180,7 @@ export default {
     connect_error(error) {
       // these are handled internally and shouldn't be forwarded to Sentry
       if (
-        error.message === "xhr poll error" || 
+        error.message === "xhr poll error" ||
         error.message === "websocket error"
       ) {
         return;

--- a/src/components/App/index.vue
+++ b/src/components/App/index.vue
@@ -175,6 +175,9 @@ export default {
   },
   sockets: {
     error(error) {
+      if (error.message === "xhr poll error") {
+        return
+      }
       Sentry.captureException(error);
     },
     connect_error(error) {


### PR DESCRIPTION
Description
-----------
- `xhr poll error`s are handled internally, we don't need to send them to Sentry. This catches those specific errors and ignores them.

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
