### PR TITLE
move from now deprecated set-env

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -26,10 +26,10 @@ jobs:
         if curl --head --silent --fail "https://github.com/UPchieve/server/tree/${{ github.head_ref }}" 2> /dev/null;
          then
           echo "found companion branch"
-          echo "::set-env name=HAS_SAME_SERVER_BRANCH::1"
+          echo "name=HAS_SAME_SERVER_BRANCH::1" >> $GITHUB_ENV
          else
           echo "did not find companion branch"
-          echo "::set-env name=HAS_SAME_SERVER_BRANCH::0"
+          echo "name=HAS_SAME_SERVER_BRANCH::0" >> $GITHUB_ENV
         fi
     # If no matching branch is found in server, checkout master to $GITHUB_WORKSPACE/server
     - name: Checkout a master branch from server repo (if there is no matching branch in server)

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -54,7 +54,7 @@ jobs:
     - run: cd server && cp config.example.ts config.ts && mkdir mongo-volume && docker-compose up -d
     - run: sleep 60
     - run: cd web && npm install
-    - uses: cypress-io/github-action@v1
+    - uses: cypress-io/github-action@v2
       with:
         working-directory: ./web
         browser: chrome

--- a/src/components/App/index.vue
+++ b/src/components/App/index.vue
@@ -178,6 +178,13 @@ export default {
       Sentry.captureException(error);
     },
     connect_error(error) {
+      // these are handled internally and shouldn't be forwarded to Sentry
+      if (
+        error.message === "xhr poll error" ||
+        error.message === "websocket error"
+      ) {
+        return;
+      }
       Sentry.captureException(error);
     },
     reconnect_error(error) {


### PR DESCRIPTION
Links
-----
- Server repo PR: https://github.com/UPchieve/server/pull/516

Description
-----------
- GitHub actions deprecated and disabled the `set-env` command - https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
