### PR TITLE
use e164 format instead of international

### DIFF
--- a/src/views/ProfileView.vue
+++ b/src/views/ProfileView.vue
@@ -155,7 +155,7 @@ export default {
       // Hack to initially mock the vue-phone-number-input data
       this.phoneInputInfo = {
         isValid: true,
-        e164: pn.getNumber("international")
+        e164: pn.getNumber("e164")
       };
     }
   },


### PR DESCRIPTION
Description
-----------
- Use e164 format on component created to avoid accidentally storing international phone number format for a user 

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
