### PR TITLE
moved openFileDialog to SessionView parent component

### DIFF
--- a/src/views/SessionView/Whiteboard.vue
+++ b/src/views/SessionView/Whiteboard.vue
@@ -233,6 +233,10 @@ export default {
     isSessionOver: {
       type: Boolean,
       required: true
+    },
+    openFileDialog: {
+      type: Function,
+      required: true
     }
   },
   data() {
@@ -397,9 +401,6 @@ export default {
 
       // Reset the file input
       event.target.value = "";
-    },
-    openFileDialog() {
-      document.querySelector(".upload-photo").click();
     },
     insertPhoto(imageUrl) {
       const nodeId = this.zwibblerCtx.createNode("ImageNode", {

--- a/src/views/SessionView/index.vue
+++ b/src/views/SessionView/index.vue
@@ -26,7 +26,7 @@
           :isWhiteboardOpen="auxiliaryOpen"
           :toggleWhiteboard="toggleAuxiliary"
           :isSessionOver="isSessionOver"
-          ref="whiteboard"
+          :openFileDialog="openFileDialog"
         />
         <document-editor v-else />
       </div>
@@ -304,7 +304,7 @@ export default {
       this.sessionReconnecting = true;
     },
     openFileDialog() {
-      this.$refs.whiteboard.openFileDialog();
+      document.querySelector(".upload-photo").click();
     }
   },
   watch: {


### PR DESCRIPTION
Description
-----------
- moved `openFileDialog` out from `Whiteboard.vue` to its parent component
- Fixes error `undefined is not an object (evaluating 'this.$refs.whiteboard.openFileDialog')`

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
