### PR TITLE
pass in missing abort fn to showTroubleStartingModal

### DIFF
--- a/src/views/SessionView/index.vue
+++ b/src/views/SessionView/index.vue
@@ -238,7 +238,8 @@ export default {
     reconnect_attempt() {
       this.$store.dispatch("user/sessionDisconnected");
       if (!this.session || !this.session._id) {
-        this.showTroubleStartingModal();
+        const abort = () => this.$router.push("/");
+        this.showTroubleStartingModal(abort);
       }
     },
     connect() {


### PR DESCRIPTION
Description
-----------
- Pass in a missing abort function to `showTroubleStartingModal` 
- Fixes error `this.modalData.abortFunction is not a function`

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
