### PR TITLE
switch order of logout methods

### DIFF
--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -128,12 +128,12 @@ export default {
     if (context) {
       NetworkService.logout(context)
         .then(() => {
-          context.$store.dispatch("user/clear");
           context.$router.push("/logout");
+          context.$store.dispatch("user/clear");
         })
         .catch(() => {
-          context.$store.dispatch("user/clear");
           context.$router.push("/logout");
+          context.$store.dispatch("user/clear");
         })
         .finally(() => {
           // disconnect socket


### PR DESCRIPTION
Description
-----------
- Fixes errors: `Cannot read property 'upchieve101' of undefined` and `undefined is not an object (evaluating 'this.certifications[this.course.quizKey]')`. When a user clicks "logout" from `TrainingView` the component gets rendered without a `user` object in the vuex store and throws the two errors mentioned. This fix first does the redirect to `/logout` and then removes the user from vuex

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
