### PR TITLE
student partner org must be selected before accessing property

### DIFF
--- a/src/views/Admin/AdminReports.vue
+++ b/src/views/Admin/AdminReports.vue
@@ -236,7 +236,7 @@ export default {
     fileTitle() {
       let title = "";
       if (this.highSchool.name) title = this.highSchool.name;
-      if (this.studentPartnerOrg.displayName)
+      if (this.studentPartnerOrg && this.studentPartnerOrg.displayName)
         title = this.studentPartnerOrg.displayName;
       if (this.isValidPartnerSite) title = this.studentPartnerSite;
 


### PR DESCRIPTION
Description
-----------
- student partner org must be selected before accessing `displayName`

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
