### PR TITLE
Allow keyboard navigation on labels to behave like the actual radio buttons were they not hidden

### DIFF
--- a/src/views/DashboardView/StudentDashboard/SubjectSelection/PresessionSurvey.vue
+++ b/src/views/DashboardView/StudentDashboard/SubjectSelection/PresessionSurvey.vue
@@ -22,7 +22,11 @@
               :id="`${question.key}_${option.value}`"
               :value="option.value"
             />
-            <label :for="`${question.key}_${option.value}`">
+            <label
+              :for="`${question.key}_${option.value}`"
+              tabindex="0"
+              @keydown.space="responses[question.key].answer = option.value"
+            >
               <span>{{ option.displayName }}</span>
               <input
                 v-if="option.value === 'other'"


### PR DESCRIPTION
Links
-----
- Issue: #590

Description
-----------
- Students can now navigate through the presession survey radio buttons by using Tab key to focus an option and space to select it

Developer self-review checklist
-------------------------------
- [x] Potentially confusing code has been explained with comments
- [x] No warnings or errors have been introduced; all known error cases have been handled
- [x] Any appropriate documentation (within the code, README.md, docs, etc) has been updated
- [x] All edge cases have been addressed
